### PR TITLE
Harden NDI runtime and subscriptions

### DIFF
--- a/Sources/NDI/NDI.swift
+++ b/Sources/NDI/NDI.swift
@@ -10,8 +10,6 @@ public struct NDI: Sendable {
 	/// The units that time is represented in (100ns) per second
 	public static let timescale: Int64 = 10_000_000
 
-	// TODO: actually call thses
-
 	var NDIlib_initialize: @Sendable () -> Bool = { false }
 
 	var NDIlib_destroy: @Sendable () -> Void
@@ -49,20 +47,85 @@ public struct NDI: Sendable {
 	var NDIlib_recv_free_metadata: @Sendable (NDIlib_recv_instance_t?, UnsafePointer<NDIlib_metadata_frame_t>?) -> Void
 }
 
-public enum NDILoadError: Error, LocalizedError {
+public enum NDILoadError: Error, Equatable, LocalizedError, Sendable {
 	case dlopenFailed(String?)
 	case loadMethodNotFound(String?)
 	case loadFailed
+	case initializationFailed
 
 	public var errorDescription: String? {
-		String(localized: "Failed to load NDI library.")
+		switch self {
+		case let .dlopenFailed(message):
+			if let message {
+				String(localized: "Failed to open the NDI library: \(message)")
+			} else {
+				String(localized: "Failed to open the NDI library.")
+			}
+		case let .loadMethodNotFound(message):
+			if let message {
+				String(localized: "Failed to find the NDI loader: \(message)")
+			} else {
+				String(localized: "Failed to find the NDI loader.")
+			}
+		case .loadFailed:
+			String(localized: "The NDI loader did not return a function table.")
+		case .initializationFailed:
+			String(localized: "The NDI library failed to initialize.")
+		}
 	}
 }
 
+final class NDILibraryRuntime: @unchecked Sendable {
+	private let destroy: @Sendable () -> Void
+	private let close: @Sendable () -> Void
+
+	init(
+		initialize: () -> Bool,
+		destroy: @escaping @Sendable () -> Void,
+		close: @escaping @Sendable () -> Void = {}
+	) throws(NDILoadError) {
+		guard initialize() else {
+			close()
+			throw NDILoadError.initializationFailed
+		}
+
+		self.destroy = destroy
+		self.close = close
+	}
+
+	deinit {
+		destroy()
+		close()
+	}
+}
+
+#if os(macOS)
+	private final class NDIDynamicLibraryHandle: @unchecked Sendable {
+		let rawValue: UnsafeMutableRawPointer
+
+		init(rawValue: UnsafeMutableRawPointer) {
+			self.rawValue = rawValue
+		}
+
+		func close() {
+			dlclose(rawValue)
+		}
+	}
+#endif
+
 public extension NDI {
 	init(_ lib: NDIlib_v5) {
+		self.init(lib, retaining: nil)
+	}
+
+	private init(_ lib: NDIlib_v5, retaining runtime: NDILibraryRuntime?) {
 		self.init(
-			NDIlib_initialize: { lib.NDIlib_initialize() },
+			NDIlib_initialize: { [runtime] in
+				if runtime != nil {
+					return true
+				}
+				return lib.NDIlib_initialize()
+			},
 			NDIlib_destroy: { lib.NDIlib_destroy() },
 
 			NDIlib_find_create_v2: { lib.NDIlib_find_create_v2($0) },
@@ -84,45 +147,80 @@ public extension NDI {
 		init(libraryPath: String) throws(NDILoadError) {
 			typealias LoadFunc = @convention(c) () -> UnsafePointer<NDIlib_v5>?
 
-			guard let handle = dlopen(libraryPath, RTLD_NOW) else {
+			guard let rawHandle = dlopen(libraryPath, RTLD_NOW) else {
 				if let errorMessage = dlerror() {
 					throw NDILoadError.dlopenFailed(String(cString: errorMessage))
 				}
 
 				throw NDILoadError.dlopenFailed(nil)
 			}
-			defer { dlclose(handle) }
-			guard let sym = dlsym(handle, "NDIlib_v5_load") else {
-				if let errorMessage = dlerror() {
-					throw NDILoadError.loadMethodNotFound(String(cString: errorMessage))
-				}
-
-				throw NDILoadError.loadMethodNotFound(nil)
+			let handle = NDIDynamicLibraryHandle(rawValue: rawHandle)
+			guard let sym = dlsym(handle.rawValue, "NDIlib_v5_load") else {
+				let errorMessage = dlerror().map { String(cString: $0) }
+				handle.close()
+				throw NDILoadError.loadMethodNotFound(errorMessage)
 			}
 			let NDIlib_v5_load = unsafeBitCast(sym, to: LoadFunc.self)
 
 			guard let libPointer = NDIlib_v5_load() else {
+				handle.close()
 				throw NDILoadError.loadFailed
 			}
 
-			self.init(libPointer.pointee)
+			let lib = libPointer.pointee
+			let runtime = try NDILibraryRuntime(
+				initialize: { lib.NDIlib_initialize() },
+				destroy: { lib.NDIlib_destroy() },
+				close: { handle.close() }
+			)
+
+			self.init(lib, retaining: runtime)
 		}
 
-		static let shared: NDI? = {
-			do {
+		static let sharedResult: Result<NDI, NDILoadError> = {
+			var lastError = NDILoadError.dlopenFailed(nil)
+			for path in ["libndi.dylib", "/usr/local/lib/libndi.dylib"] {
 				do {
-					return try NDI(libraryPath: "libndi.dylib")
+					return try .success(NDI(libraryPath: path))
 				} catch {
-					return try NDI(libraryPath: "/usr/local/lib/libndi.dylib")
+					let loadError = error as? NDILoadError ?? .loadFailed
+					if loadError == .initializationFailed {
+						return .failure(loadError)
+					}
+					lastError = loadError
 				}
-			} catch {
-				logger.error("Failed to load NDI: \(error)")
-				return nil
 			}
+
+			return .failure(lastError)
 		}()
 	#else
-		static let shared = NDI(NDIlib_v5_load().pointee)
+		static let sharedResult: Result<NDI, NDILoadError> = {
+			guard let libPointer = NDIlib_v5_load() else {
+				return .failure(.loadFailed)
+			}
+
+			let lib = libPointer.pointee
+			do {
+				let runtime = try NDILibraryRuntime(
+					initialize: { lib.NDIlib_initialize() },
+					destroy: { lib.NDIlib_destroy() }
+				)
+				return .success(NDI(lib, retaining: runtime))
+			} catch {
+				return .failure(error as? NDILoadError ?? .initializationFailed)
+			}
+		}()
 	#endif
+
+	static let shared: NDI? = {
+		switch sharedResult {
+		case let .success(ndi):
+			return ndi
+		case let .failure(error):
+			logger.error("Failed to load NDI: \(error)")
+			return nil
+		}
+	}()
 }
 
 extension NDI: DependencyKey {

--- a/Sources/NDI/NDIPlayer.swift
+++ b/Sources/NDI/NDIPlayer.swift
@@ -22,6 +22,14 @@ public enum NDIFrameBufferingPolicy: Equatable, Sendable {
 	}
 }
 
+public struct NDIFrameMarker: Equatable, Hashable, Identifiable, Sendable {
+	public let id: UUID
+
+	public init(id: UUID = UUID()) {
+		self.id = id
+	}
+}
+
 struct NDIFrameCapture: Sendable {
 	var capture: @Sendable () -> NDIReceivedFrame
 
@@ -263,8 +271,13 @@ public actor NDIPlayer {
 
 	private func receive(frame: NDIReceivedFrame, from id: UUID) {
 		guard case .running(id, _) = receiveLoopState else { return }
+		broadcast(frame)
+	}
 
+	private func broadcast(_ frame: NDIReceivedFrame) {
 		for subscription in frameSubscriptions.values {
+			guard subscription.including?(frame) ?? true else { continue }
+
 			switch subscription.continuation.yield(frame) {
 			case .enqueued, .terminated:
 				break
@@ -283,10 +296,12 @@ public actor NDIPlayer {
 
 	public typealias FrameStream = AsyncStream<NDIReceivedFrame>
 	public typealias DroppedFrameHandler = @Sendable (NDIReceivedFrame) -> Void
+	public typealias FrameInclusion = @Sendable (NDIReceivedFrame) -> Bool
 
 	private struct FrameSubscription {
 		var continuation: FrameStream.Continuation
 		var onDroppedFrame: DroppedFrameHandler?
+		var including: FrameInclusion?
 	}
 
 	private var frameSubscriptions: [UUID: FrameSubscription] = [:]
@@ -298,13 +313,15 @@ public actor NDIPlayer {
 	private func registerContinuation(
 		_ continuation: FrameStream.Continuation,
 		token: NDIFrameSubscriptionToken,
-		onDroppedFrame: DroppedFrameHandler?
+		onDroppedFrame: DroppedFrameHandler?,
+		including: FrameInclusion?
 	) async {
 		guard !token.isCancelled else { return }
 
 		frameSubscriptions[token.id] = FrameSubscription(
 			continuation: continuation,
-			onDroppedFrame: onDroppedFrame
+			onDroppedFrame: onDroppedFrame,
+			including: including
 		)
 		await reconcileReceiving()
 	}
@@ -322,6 +339,35 @@ public actor NDIPlayer {
 		bufferingPolicy: NDIFrameBufferingPolicy,
 		onDroppedFrame: DroppedFrameHandler? = nil
 	) -> FrameStream {
+		makeFrameStream(
+			bufferingPolicy: bufferingPolicy,
+			including: nil,
+			onDroppedFrame: onDroppedFrame
+		)
+	}
+
+	/// Creates a filtered frame stream with a policy specific to this subscriber.
+	///
+	/// `including` runs before buffering, so excluded frames cannot consume capacity
+	/// or evict an included frame. `including` and `onDroppedFrame` run on the player
+	/// actor and should return quickly.
+	public nonisolated func frames(
+		bufferingPolicy: NDIFrameBufferingPolicy,
+		including: @escaping FrameInclusion,
+		onDroppedFrame: DroppedFrameHandler? = nil
+	) -> FrameStream {
+		makeFrameStream(
+			bufferingPolicy: bufferingPolicy,
+			including: including,
+			onDroppedFrame: onDroppedFrame
+		)
+	}
+
+	private nonisolated func makeFrameStream(
+		bufferingPolicy: NDIFrameBufferingPolicy,
+		including: FrameInclusion?,
+		onDroppedFrame: DroppedFrameHandler?
+	) -> FrameStream {
 		let token = NDIFrameSubscriptionToken()
 		let (stream, continuation) = FrameStream.makeStream(bufferingPolicy: bufferingPolicy.streamPolicy)
 
@@ -336,11 +382,22 @@ public actor NDIPlayer {
 			await self?.registerContinuation(
 				continuation,
 				token: token,
-				onDroppedFrame: onDroppedFrame
+				onDroppedFrame: onDroppedFrame,
+				including: including
 			)
 		}
 
 		return stream
+	}
+
+	/// Places a marker after frames already delivered to each current subscriber.
+	///
+	/// The marker uses each subscriber's normal filtering and buffering policy. If
+	/// it is evicted later, it is delivered to that subscriber's drop handler.
+	@discardableResult
+	public func yieldMarker(_ marker: NDIFrameMarker = NDIFrameMarker()) -> NDIFrameMarker {
+		broadcast(.marker(marker))
+		return marker
 	}
 
 	/// Compatibility overload retaining the original 60-frame default.

--- a/Sources/NDI/NDIPlayer.swift
+++ b/Sources/NDI/NDIPlayer.swift
@@ -368,6 +368,70 @@ public actor NDIPlayer {
 		including: FrameInclusion?,
 		onDroppedFrame: DroppedFrameHandler?
 	) -> FrameStream {
+		let preparedStream = prepareFrameStream(bufferingPolicy: bufferingPolicy)
+
+		Task { [weak self, token = preparedStream.token] in
+			await self?.registerContinuation(
+				preparedStream.continuation,
+				token: token,
+				onDroppedFrame: onDroppedFrame,
+				including: including
+			)
+		}
+
+		return preparedStream.stream
+	}
+
+	/// Creates a frame stream after registering this specific subscription.
+	///
+	/// A frame or marker yielded after this method returns is visible to this
+	/// subscription, subject to its buffering policy.
+	public func registeredFrames(
+		bufferingPolicy: NDIFrameBufferingPolicy,
+		onDroppedFrame: DroppedFrameHandler? = nil
+	) async -> FrameStream {
+		await makeRegisteredFrameStream(
+			bufferingPolicy: bufferingPolicy,
+			including: nil,
+			onDroppedFrame: onDroppedFrame
+		)
+	}
+
+	/// Creates a filtered frame stream after registering this specific subscription.
+	///
+	/// `including` runs before buffering. A frame or marker included and yielded
+	/// after this method returns is visible to this subscription, subject to its
+	/// buffering policy.
+	public func registeredFrames(
+		bufferingPolicy: NDIFrameBufferingPolicy,
+		including: @escaping FrameInclusion,
+		onDroppedFrame: DroppedFrameHandler? = nil
+	) async -> FrameStream {
+		await makeRegisteredFrameStream(
+			bufferingPolicy: bufferingPolicy,
+			including: including,
+			onDroppedFrame: onDroppedFrame
+		)
+	}
+
+	private func makeRegisteredFrameStream(
+		bufferingPolicy: NDIFrameBufferingPolicy,
+		including: FrameInclusion?,
+		onDroppedFrame: DroppedFrameHandler?
+	) async -> FrameStream {
+		let preparedStream = prepareFrameStream(bufferingPolicy: bufferingPolicy)
+		await registerContinuation(
+			preparedStream.continuation,
+			token: preparedStream.token,
+			onDroppedFrame: onDroppedFrame,
+			including: including
+		)
+		return preparedStream.stream
+	}
+
+	private nonisolated func prepareFrameStream(
+		bufferingPolicy: NDIFrameBufferingPolicy
+	) -> (stream: FrameStream, continuation: FrameStream.Continuation, token: NDIFrameSubscriptionToken) {
 		let token = NDIFrameSubscriptionToken()
 		let (stream, continuation) = FrameStream.makeStream(bufferingPolicy: bufferingPolicy.streamPolicy)
 
@@ -378,16 +442,7 @@ public actor NDIPlayer {
 			}
 		}
 
-		Task { [weak self, token] in
-			await self?.registerContinuation(
-				continuation,
-				token: token,
-				onDroppedFrame: onDroppedFrame,
-				including: including
-			)
-		}
-
-		return stream
+		return (stream, continuation, token)
 	}
 
 	/// Places a marker after frames already delivered to each current subscriber.
@@ -399,6 +454,12 @@ public actor NDIPlayer {
 		broadcast(.marker(marker))
 		return marker
 	}
+
+	/// Provides an actor barrier for frame delivery.
+	///
+	/// After this method returns, drop handlers for frames received or yielded
+	/// before the call have completed.
+	public func synchronizeFrameDelivery() {}
 
 	/// Compatibility overload retaining the original 60-frame default.
 	public nonisolated func frames(bufferingNewest: Int = 60) -> FrameStream {

--- a/Sources/NDI/NDIPlayer.swift
+++ b/Sources/NDI/NDIPlayer.swift
@@ -2,6 +2,122 @@ import Foundation
 import libNDI
 import Synchronization
 
+public enum NDIFrameBufferingPolicy: Equatable, Sendable {
+	case unbounded
+	case bufferingOldest(Int)
+	case bufferingNewest(Int)
+
+	/// Keeps only the frame a low-latency consumer can display next.
+	public static let lowLatency = Self.bufferingNewest(1)
+
+	fileprivate var streamPolicy: AsyncStream<NDIReceivedFrame>.Continuation.BufferingPolicy {
+		switch self {
+		case .unbounded:
+			.unbounded
+		case let .bufferingOldest(limit):
+			.bufferingOldest(limit)
+		case let .bufferingNewest(limit):
+			.bufferingNewest(limit)
+		}
+	}
+}
+
+struct NDIFrameCapture: Sendable {
+	var capture: @Sendable () -> NDIReceivedFrame
+
+	func callAsFunction() -> NDIReceivedFrame {
+		capture()
+	}
+}
+
+struct NDIReceiveLoopCallbacks: Sendable {
+	var receive: @Sendable (NDIReceivedFrame) async -> Void
+	var didStop: @Sendable () async -> Void
+}
+
+struct NDIReceiveLoopHandle: Sendable {
+	var cancelOperation: @Sendable () -> Void
+
+	func cancel() {
+		cancelOperation()
+	}
+}
+
+struct NDIReceiveLoopStarter: Sendable {
+	var start: @Sendable (NDIFrameCapture, NDIReceiveLoopCallbacks) -> NDIReceiveLoopHandle
+
+	func callAsFunction(
+		capture: NDIFrameCapture,
+		callbacks: NDIReceiveLoopCallbacks
+	) -> NDIReceiveLoopHandle {
+		start(capture, callbacks)
+	}
+
+	static let live = Self { capture, callbacks in
+		let loop = NDIThreadReceiveLoop(capture: capture, callbacks: callbacks)
+		return NDIReceiveLoopHandle {
+			loop.cancel()
+		}
+	}
+}
+
+private final class NDIThreadReceiveLoop: @unchecked Sendable {
+	private let thread: Thread
+
+	init(capture: NDIFrameCapture, callbacks: NDIReceiveLoopCallbacks) {
+		let thread = Thread {
+			defer {
+				Self.wait {
+					await callbacks.didStop()
+				}
+			}
+
+			while !Thread.current.isCancelled {
+				let frame = capture()
+				guard !Thread.current.isCancelled else { return }
+
+				Self.wait {
+					await callbacks.receive(frame)
+				}
+			}
+		}
+		thread.name = "swift-ndi.receive"
+		thread.qualityOfService = .userInitiated
+		self.thread = thread
+		thread.start()
+	}
+
+	deinit {
+		thread.cancel()
+	}
+
+	func cancel() {
+		thread.cancel()
+	}
+
+	private static func wait(for operation: @escaping @Sendable () async -> Void) {
+		let semaphore = DispatchSemaphore(value: 0)
+		Task {
+			await operation()
+			semaphore.signal()
+		}
+		semaphore.wait()
+	}
+}
+
+private final class NDIFrameSubscriptionToken: @unchecked Sendable {
+	let id = UUID()
+	private let cancelled = Mutex(false)
+
+	var isCancelled: Bool {
+		cancelled.withLock { $0 }
+	}
+
+	func cancel() {
+		cancelled.withLock { $0 = true }
+	}
+}
+
 public actor NDIPlayer {
 	private static let playerPool: Mutex<[String: Weak<NDIPlayer>]> = .init([:])
 
@@ -17,136 +133,219 @@ public actor NDIPlayer {
 		}
 	}
 
-	nonisolated
-	public let sourceName: String
+	public nonisolated let sourceName: String
 	private var source: NDISource?
+
+	private let makeCapture: @Sendable (NDISource?, String) async -> NDIFrameCapture?
+	private let startReceiveLoop: NDIReceiveLoopStarter
 
 	public init(name: String) {
 		self.sourceName = name
+		self.makeCapture = Self.liveCapture
+		self.startReceiveLoop = .live
 	}
 
 	public init(source: NDISource) {
 		self.sourceName = source.name
 		self.source = source
+		self.makeCapture = Self.liveCapture
+		self.startReceiveLoop = .live
 	}
 
-	private var getReceiverTask: Task<NDIReceiver?, Never>?
+	init(
+		name: String,
+		capture: NDIFrameCapture,
+		startReceiveLoop: NDIReceiveLoopStarter
+	) {
+		self.sourceName = name
+		self.makeCapture = { _, _ in capture }
+		self.startReceiveLoop = startReceiveLoop
+	}
 
-	private func getReceiver() async -> NDIReceiver? {
-		if let getReceiverTask {
-			return await getReceiverTask.value
+	private static func liveCapture(source: NDISource?, sourceName: String) async -> NDIFrameCapture? {
+		let receiver: NDIReceiver
+		if let source {
+			guard let sourceReceiver = NDIReceiver(source: source) else { return nil }
+			receiver = sourceReceiver
 		} else {
-			let task = Task { () -> NDIReceiver? in
-				if let source {
-					guard let receiver = NDIReceiver(source: source) else { return nil }
+			guard let namedReceiver = NDIReceiver() else { return nil }
+			await namedReceiver.connect(name: sourceName)
+			receiver = namedReceiver
+		}
 
-					return receiver
-				} else {
-					guard let receiver = NDIReceiver() else { return nil }
+		return NDIFrameCapture {
+			receiver.capture(timeout: .seconds(1))
+		}
+	}
 
-					await receiver.connect(name: sourceName)
+	private var getCaptureTask: Task<NDIFrameCapture?, Never>?
 
-					return receiver
-				}
+	private func getCapture() async -> NDIFrameCapture? {
+		if let getCaptureTask {
+			return await getCaptureTask.value
+		}
+
+		let source = self.source
+		let sourceName = self.sourceName
+		let makeCapture = self.makeCapture
+		let task = Task {
+			await makeCapture(source, sourceName)
+		}
+		getCaptureTask = task
+		return await task.value
+	}
+
+	private enum ReceiveLoopState {
+		case stopped
+		case starting(UUID)
+		case running(UUID, NDIReceiveLoopHandle)
+		case stopping(UUID)
+	}
+
+	private var receiveLoopState = ReceiveLoopState.stopped
+
+	private func reconcileReceiving() async {
+		guard !frameSubscriptions.isEmpty else {
+			if case let .running(id, loop) = receiveLoopState {
+				receiveLoopState = .stopping(id)
+				loop.cancel()
+			} else if case let .starting(id) = receiveLoopState {
+				receiveLoopState = .stopping(id)
 			}
-			getReceiverTask = task
-			return await task.value
+			return
 		}
-	}
 
-	private var lastVideoFrame: NDIReceivedVideoFrame?
+		guard case .stopped = receiveLoopState else { return }
 
-	private var receiveThread: Thread? {
-		didSet {
-			oldValue?.cancel()
-		}
-	}
-
-	private func updateReceiving() async {
-		if framesContinuations.isEmpty {
-			receiveThread = nil
-		} else {
-			await self.receive()
-		}
-	}
-
-	private func receive() async {
-		guard let receiver = await getReceiver() else { return }
-
-		// It is much more efficient to let NDIlib_recv_capture_v3 wait for a new frame
-		// but that will block the thread it is running on
-		// to avoid blocking a thread from the general executor pool, we create our own thread to wait on
-		let thread = Thread { [weak self] in
-			while !Thread.current.isCancelled {
-				// this timeout will determine how long it takes after cancellation to clean up resources
-				let frame = receiver.capture(timeout: .seconds(1))
-
-				if let self {
-					Task {
-						await self.receive(frame: frame)
-					}
-				} else {
-					return
-				}
+		let id = UUID()
+		receiveLoopState = .starting(id)
+		guard let capture = await getCapture() else {
+			if case .starting(id) = receiveLoopState {
+				receiveLoopState = .stopped
 			}
+			return
 		}
-		thread.start()
-		receiveThread = thread
+
+		guard case .starting(id) = receiveLoopState else {
+			if case .stopping(id) = receiveLoopState {
+				receiveLoopState = .stopped
+				await reconcileReceiving()
+			}
+			return
+		}
+
+		let callbacks = NDIReceiveLoopCallbacks(
+			receive: { [weak self] frame in
+				await self?.receive(frame: frame, from: id)
+			},
+			didStop: { [weak self] in
+				await self?.receiveLoopDidStop(id: id)
+			}
+		)
+		let loop = startReceiveLoop(capture: capture, callbacks: callbacks)
+		receiveLoopState = .running(id, loop)
+
+		if frameSubscriptions.isEmpty {
+			receiveLoopState = .stopping(id)
+			loop.cancel()
+		}
 	}
 
-	private func receive(frame: NDIReceivedFrame) {
-		for (_, continuation) in framesContinuations {
-			continuation.yield(frame)
-		}
-
-		switch frame {
-		case let .video(frame):
-			lastVideoFrame = frame
-		default:
+	private func receiveLoopDidStop(id: UUID) async {
+		switch receiveLoopState {
+		case .running(id, _), .stopping(id):
+			receiveLoopState = .stopped
+			await reconcileReceiving()
+		case .stopped, .starting, .running, .stopping:
 			break
+		}
+	}
+
+	private func receive(frame: NDIReceivedFrame, from id: UUID) {
+		guard case .running(id, _) = receiveLoopState else { return }
+
+		for subscription in frameSubscriptions.values {
+			switch subscription.continuation.yield(frame) {
+			case .enqueued, .terminated:
+				break
+			case let .dropped(droppedFrame):
+				subscription.onDroppedFrame?(droppedFrame)
+			@unknown default:
+				break
+			}
 		}
 	}
 
 	@discardableResult
 	public func connect() async -> Bool {
-		await getReceiver() != nil
+		await getCapture() != nil
 	}
 
 	public typealias FrameStream = AsyncStream<NDIReceivedFrame>
+	public typealias DroppedFrameHandler = @Sendable (NDIReceivedFrame) -> Void
 
-	private var framesContinuations: [UUID: FrameStream.Continuation] = [:]
+	private struct FrameSubscription {
+		var continuation: FrameStream.Continuation
+		var onDroppedFrame: DroppedFrameHandler?
+	}
 
-	private func registerContinuation(_ continuation: FrameStream.Continuation) async {
-		if let lastVideoFrame {
-			continuation.yield(.video(lastVideoFrame))
-		}
+	private var frameSubscriptions: [UUID: FrameSubscription] = [:]
 
-		let id = UUID()
-		framesContinuations[id] = continuation
+	var activeSubscriptionCount: Int {
+		frameSubscriptions.count
+	}
 
-		continuation.onTermination = { reason in
-			Task {
-				await self.unregisterContinuation(id)
-			}
-		}
+	private func registerContinuation(
+		_ continuation: FrameStream.Continuation,
+		token: NDIFrameSubscriptionToken,
+		onDroppedFrame: DroppedFrameHandler?
+	) async {
+		guard !token.isCancelled else { return }
 
-		await updateReceiving()
+		frameSubscriptions[token.id] = FrameSubscription(
+			continuation: continuation,
+			onDroppedFrame: onDroppedFrame
+		)
+		await reconcileReceiving()
 	}
 
 	private func unregisterContinuation(_ id: UUID) async {
-		self.framesContinuations.removeValue(forKey: id)
-
-		await updateReceiving()
+		frameSubscriptions.removeValue(forKey: id)
+		await reconcileReceiving()
 	}
 
-	public nonisolated func frames(bufferingNewest: Int = 60) -> FrameStream {
-		let (stream, continuation) = FrameStream.makeStream(bufferingPolicy: .bufferingNewest(bufferingNewest))
+	/// Creates a frame stream with a policy specific to this subscriber.
+	///
+	/// `onDroppedFrame` runs when this subscriber's buffer evicts a frame. It should
+	/// return quickly so it does not delay delivery to the other subscribers.
+	public nonisolated func frames(
+		bufferingPolicy: NDIFrameBufferingPolicy,
+		onDroppedFrame: DroppedFrameHandler? = nil
+	) -> FrameStream {
+		let token = NDIFrameSubscriptionToken()
+		let (stream, continuation) = FrameStream.makeStream(bufferingPolicy: bufferingPolicy.streamPolicy)
 
-		Task {
-			await self.registerContinuation(continuation)
+		continuation.onTermination = { [weak self, token] _ in
+			token.cancel()
+			Task {
+				await self?.unregisterContinuation(token.id)
+			}
+		}
+
+		Task { [weak self, token] in
+			await self?.registerContinuation(
+				continuation,
+				token: token,
+				onDroppedFrame: onDroppedFrame
+			)
 		}
 
 		return stream
+	}
+
+	/// Compatibility overload retaining the original 60-frame default.
+	public nonisolated func frames(bufferingNewest: Int = 60) -> FrameStream {
+		frames(bufferingPolicy: .bufferingNewest(bufferingNewest))
 	}
 
 	public nonisolated var videoFrames: some (AsyncSequence<NDIReceivedVideoFrame, Never> & Sendable) {

--- a/Sources/NDI/NDIReceiver.swift
+++ b/Sources/NDI/NDIReceiver.swift
@@ -132,4 +132,5 @@ public enum NDIReceivedFrame: Sendable {
 	case metadata(NDIMetadataFrame)
 	case statusChange
 	case unknown
+	case marker(NDIFrameMarker)
 }

--- a/Sources/NDI/NDIView.swift
+++ b/Sources/NDI/NDIView.swift
@@ -122,8 +122,9 @@ public class NDIViewCoordinator: NSObject, MTKViewDelegate {
 
 	func play() {
 		playerTask = Task { [weak self, player] in
-			for await frame in player.videoFrames {
-				self?.frame = frame
+			for await frame in player.frames(bufferingPolicy: .lowLatency) {
+				guard case let .video(videoFrame) = frame else { continue }
+				self?.frame = videoFrame
 			}
 		}
 	}

--- a/Tests/NDITests/NDILibraryRuntimeTests.swift
+++ b/Tests/NDITests/NDILibraryRuntimeTests.swift
@@ -1,0 +1,51 @@
+import Synchronization
+import Testing
+@testable import NDI
+
+struct NDILibraryRuntimeTests {
+	@Test
+	func initializesOnceAndDestroysBeforeClosing() throws {
+		let events = Mutex<[String]>([])
+		var runtime: NDILibraryRuntime? = try NDILibraryRuntime(
+			initialize: {
+				events.withLock { $0.append("initialize") }
+				return true
+			},
+			destroy: {
+				events.withLock { $0.append("destroy") }
+			},
+			close: {
+				events.withLock { $0.append("close") }
+			}
+		)
+
+		#expect(events.withLock { $0 } == ["initialize"])
+		#expect(runtime != nil)
+
+		runtime = nil
+
+		#expect(events.withLock { $0 } == ["initialize", "destroy", "close"])
+	}
+
+	@Test
+	func closesWithoutDestroyingWhenInitializationFails() {
+		let events = Mutex<[String]>([])
+
+		#expect(throws: NDILoadError.initializationFailed) {
+			_ = try NDILibraryRuntime(
+				initialize: {
+					events.withLock { $0.append("initialize") }
+					return false
+				},
+				destroy: {
+					events.withLock { $0.append("destroy") }
+				},
+				close: {
+					events.withLock { $0.append("close") }
+				}
+			)
+		}
+
+		#expect(events.withLock { $0 } == ["initialize", "close"])
+	}
+}

--- a/Tests/NDITests/NDIPlayerTests.swift
+++ b/Tests/NDITests/NDIPlayerTests.swift
@@ -1,5 +1,6 @@
 import ConcurrencyExtras
 import Dependencies
+import Foundation
 import libNDI
 import Synchronization
 import Testing
@@ -61,12 +62,9 @@ struct NDIPlayerTests {
 			startReceiveLoop: probe.starter
 		)
 		let droppedFrameCount = Mutex(0)
-		let stream = player.frames(
-			bufferingPolicy: .bufferingNewest(1),
-			onDroppedFrame: { _ in
-				droppedFrameCount.withLock { $0 += 1 }
-			}
-		)
+		let stream = player.frames(bufferingPolicy: .bufferingNewest(1)) { _ in
+			droppedFrameCount.withLock { $0 += 1 }
+		}
 		#expect(await startEvents.next() == 1)
 
 		await probe.send(.none, toLoopAt: 0)
@@ -123,6 +121,128 @@ struct NDIPlayerTests {
 		secondConsumer.cancel()
 		await firstConsumer.value
 		await secondConsumer.value
+		await Task.megaYield()
+		await probe.stopLoop(at: 0)
+	}
+
+	@Test
+	func filtersFramesBeforeTheyConsumeBufferCapacity() async {
+		let probe = ReceiveLoopProbe()
+		var startEvents = probe.startEvents.makeAsyncIterator()
+		let player = NDIPlayer(
+			name: "Test",
+			capture: NDIFrameCapture { .none },
+			startReceiveLoop: probe.starter
+		)
+		let droppedFrameCount = Mutex(0)
+		let stream = player.frames(
+			bufferingPolicy: .bufferingNewest(1),
+			including: { frame in
+				if case .unknown = frame {
+					return true
+				}
+				return false
+			},
+			onDroppedFrame: { _ in
+				droppedFrameCount.withLock { $0 += 1 }
+			}
+		)
+		#expect(await startEvents.next() == 1)
+
+		await probe.send(.unknown, toLoopAt: 0)
+		await probe.send(.statusChange, toLoopAt: 0)
+
+		#expect(droppedFrameCount.withLock { $0 } == 0)
+		var iterator = stream.makeAsyncIterator()
+		let frame = await iterator.next()
+		if case .unknown? = frame {
+			// Expected: the excluded status did not evict the included frame.
+		} else {
+			Issue.record("An excluded frame consumed subscriber buffer capacity")
+		}
+
+		let consumer = consume(stream)
+		consumer.cancel()
+		await consumer.value
+		await Task.megaYield()
+		await probe.stopLoop(at: 0)
+	}
+
+	@Test
+	func markerIsOrderedWithReceivedFrames() async throws {
+		let probe = ReceiveLoopProbe()
+		var startEvents = probe.startEvents.makeAsyncIterator()
+		let player = NDIPlayer(
+			name: "Test",
+			capture: NDIFrameCapture { .none },
+			startReceiveLoop: probe.starter
+		)
+		let stream = player.frames(bufferingPolicy: .bufferingNewest(3))
+		#expect(await startEvents.next() == 1)
+
+		await probe.send(.statusChange, toLoopAt: 0)
+		let marker = try NDIFrameMarker(id: #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")))
+		#expect(await player.yieldMarker(marker) == marker)
+		await probe.send(.unknown, toLoopAt: 0)
+
+		var iterator = stream.makeAsyncIterator()
+		if case .statusChange? = await iterator.next() {
+			// Expected first frame.
+		} else {
+			Issue.record("Expected the received frame before the marker")
+		}
+		if case let .marker(receivedMarker)? = await iterator.next() {
+			#expect(receivedMarker == marker)
+		} else {
+			Issue.record("Expected the marker between received frames")
+		}
+		if case .unknown? = await iterator.next() {
+			// Expected final frame.
+		} else {
+			Issue.record("Expected the received frame after the marker")
+		}
+
+		let consumer = consume(stream)
+		consumer.cancel()
+		await consumer.value
+		await Task.megaYield()
+		await probe.stopLoop(at: 0)
+	}
+
+	@Test
+	func evictedMarkerIsDeliveredToDropHandler() async throws {
+		let probe = ReceiveLoopProbe()
+		var startEvents = probe.startEvents.makeAsyncIterator()
+		let player = NDIPlayer(
+			name: "Test",
+			capture: NDIFrameCapture { .none },
+			startReceiveLoop: probe.starter
+		)
+		let droppedMarkers = Mutex<[NDIFrameMarker]>([])
+		let stream = player.frames(
+			bufferingPolicy: .bufferingNewest(1),
+			onDroppedFrame: { frame in
+				guard case let .marker(marker) = frame else { return }
+				droppedMarkers.withLock { $0.append(marker) }
+			}
+		)
+		#expect(await startEvents.next() == 1)
+
+		let marker = try NDIFrameMarker(id: #require(UUID(uuidString: "11111111-2222-3333-4444-555555555555")))
+		await player.yieldMarker(marker)
+		await probe.send(.unknown, toLoopAt: 0)
+
+		#expect(droppedMarkers.withLock { $0 } == [marker])
+		var iterator = stream.makeAsyncIterator()
+		if case .unknown? = await iterator.next() {
+			// Expected: the later frame evicted the marker.
+		} else {
+			Issue.record("Expected the newest received frame")
+		}
+
+		let consumer = consume(stream)
+		consumer.cancel()
+		await consumer.value
 		await Task.megaYield()
 		await probe.stopLoop(at: 0)
 	}

--- a/Tests/NDITests/NDIPlayerTests.swift
+++ b/Tests/NDITests/NDIPlayerTests.swift
@@ -1,0 +1,236 @@
+import ConcurrencyExtras
+import Dependencies
+import libNDI
+import Synchronization
+import Testing
+@testable import NDI
+
+struct NDIPlayerTests {
+	@Test
+	func sharesOneReceiveLoopAndWaitsForItToStopBeforeRestarting() async throws {
+		let probe = ReceiveLoopProbe()
+		var startEvents = probe.startEvents.makeAsyncIterator()
+		let player = NDIPlayer(
+			name: "Test",
+			capture: NDIFrameCapture { .none },
+			startReceiveLoop: probe.starter
+		)
+
+		let firstConsumer = consume(player.frames())
+		#expect(await startEvents.next() == 1)
+
+		let secondConsumer = consume(player.frames())
+		await Task.megaYield()
+		#expect(await player.activeSubscriptionCount == 2)
+		#expect(probe.startCount == 1)
+
+		firstConsumer.cancel()
+		await firstConsumer.value
+		await Task.megaYield()
+		#expect(await player.activeSubscriptionCount == 1)
+		#expect(probe.cancelCount == 0)
+
+		secondConsumer.cancel()
+		await secondConsumer.value
+		await Task.megaYield()
+		#expect(await player.activeSubscriptionCount == 0)
+		#expect(probe.cancelCount == 1)
+
+		let thirdConsumer = consume(player.frames())
+		await Task.megaYield()
+		#expect(await player.activeSubscriptionCount == 1)
+		#expect(probe.startCount == 1)
+
+		await probe.stopLoop(at: 0)
+		#expect(await startEvents.next() == 2)
+		#expect(probe.maximumActiveLoopCount == 1)
+
+		thirdConsumer.cancel()
+		await thirdConsumer.value
+		await Task.megaYield()
+		await probe.stopLoop(at: 1)
+	}
+
+	@Test
+	func reportsFramesEvictedFromEachSubscribersBuffer() async {
+		let probe = ReceiveLoopProbe()
+		var startEvents = probe.startEvents.makeAsyncIterator()
+		let player = NDIPlayer(
+			name: "Test",
+			capture: NDIFrameCapture { .none },
+			startReceiveLoop: probe.starter
+		)
+		let droppedFrameCount = Mutex(0)
+		let stream = player.frames(
+			bufferingPolicy: .bufferingNewest(1),
+			onDroppedFrame: { _ in
+				droppedFrameCount.withLock { $0 += 1 }
+			}
+		)
+		#expect(await startEvents.next() == 1)
+
+		await probe.send(.none, toLoopAt: 0)
+		await probe.send(.statusChange, toLoopAt: 0)
+		await probe.send(.unknown, toLoopAt: 0)
+
+		#expect(droppedFrameCount.withLock { $0 } == 2)
+		var iterator = stream.makeAsyncIterator()
+		let frame = await iterator.next()
+		if case .unknown? = frame {
+			// Expected: the newest frame remains buffered.
+		} else {
+			Issue.record("Expected the newest frame to remain buffered")
+		}
+
+		let consumer = consume(stream)
+		consumer.cancel()
+		await consumer.value
+		await Task.megaYield()
+		await probe.stopLoop(at: 0)
+	}
+
+	@Test
+	func doesNotReplayTheLastVideoFrameToANewSubscriber() async throws {
+		let probe = ReceiveLoopProbe()
+		var startEvents = probe.startEvents.makeAsyncIterator()
+		let player = NDIPlayer(
+			name: "Test",
+			capture: NDIFrameCapture { .none },
+			startReceiveLoop: probe.starter
+		)
+		let firstStream = player.frames()
+		#expect(await startEvents.next() == 1)
+
+		let videoFrame = try makeVideoFrame()
+		await probe.send(.video(videoFrame), toLoopAt: 0)
+
+		let secondStream = player.frames()
+		await Task.megaYield()
+		#expect(await player.activeSubscriptionCount == 2)
+		await probe.send(.unknown, toLoopAt: 0)
+
+		var secondIterator = secondStream.makeAsyncIterator()
+		let firstFrameForSecondSubscriber = await secondIterator.next()
+		if case .unknown? = firstFrameForSecondSubscriber {
+			// Expected: only a frame received after subscribing is delivered.
+		} else {
+			Issue.record("A new subscriber received a stale video frame")
+		}
+
+		let firstConsumer = consume(firstStream)
+		let secondConsumer = consume(secondStream)
+		firstConsumer.cancel()
+		secondConsumer.cancel()
+		await firstConsumer.value
+		await secondConsumer.value
+		await Task.megaYield()
+		await probe.stopLoop(at: 0)
+	}
+
+	private func consume(_ stream: NDIPlayer.FrameStream) -> Task<Void, Never> {
+		Task {
+			for await _ in stream {}
+		}
+	}
+
+	private func makeVideoFrame() throws -> NDIReceivedVideoFrame {
+		var ndi = NDI()
+		ndi.NDIlib_recv_create_v3 = { _ in
+			NDIlib_recv_instance_t(bitPattern: 123)
+		}
+		ndi.NDIlib_recv_destroy = { _ in }
+		ndi.NDIlib_recv_free_video_v2 = { _, _ in }
+
+		let receiver = try #require(withDependencies {
+			$0.ndi = ndi
+		} operation: {
+			NDIReceiver()
+		})
+		let frame = NDIlib_video_frame_v2_t(
+			xres: 1,
+			yres: 1,
+			FourCC: NDIlib_FourCC_video_type_UYVY,
+			frame_rate_N: 60,
+			frame_rate_D: 1,
+			picture_aspect_ratio: 1,
+			frame_format_type: NDIlib_frame_format_type_progressive,
+			timecode: 0,
+			p_data: nil,
+			NDIlib_video_frame_v2_t.__Unnamed_union___Anonymous_field9(),
+			p_metadata: nil,
+			timestamp: 0
+		)
+		return NDIReceivedVideoFrame(frame, receiver: receiver)
+	}
+}
+
+private final class ReceiveLoopProbe: @unchecked Sendable {
+	private struct Loop: Sendable {
+		var callbacks: NDIReceiveLoopCallbacks
+		var isActive = true
+	}
+
+	private struct State: Sendable {
+		var loops: [Loop] = []
+		var cancelCount = 0
+		var activeLoopCount = 0
+		var maximumActiveLoopCount = 0
+	}
+
+	private let state = Mutex(State())
+	private let startEventsContinuation: AsyncStream<Int>.Continuation
+	let startEvents: AsyncStream<Int>
+
+	init() {
+		(startEvents, startEventsContinuation) = AsyncStream.makeStream()
+	}
+
+	deinit {
+		startEventsContinuation.finish()
+	}
+
+	var starter: NDIReceiveLoopStarter {
+		NDIReceiveLoopStarter { [self] _, callbacks in
+			let index = state.withLock { state in
+				let index = state.loops.endIndex
+				state.loops.append(Loop(callbacks: callbacks))
+				state.activeLoopCount += 1
+				state.maximumActiveLoopCount = max(state.maximumActiveLoopCount, state.activeLoopCount)
+				return index
+			}
+			startEventsContinuation.yield(index + 1)
+
+			return NDIReceiveLoopHandle { [self] in
+				state.withLock { $0.cancelCount += 1 }
+			}
+		}
+	}
+
+	var startCount: Int {
+		state.withLock { $0.loops.count }
+	}
+
+	var cancelCount: Int {
+		state.withLock { $0.cancelCount }
+	}
+
+	var maximumActiveLoopCount: Int {
+		state.withLock { $0.maximumActiveLoopCount }
+	}
+
+	func send(_ frame: NDIReceivedFrame, toLoopAt index: Int) async {
+		let callbacks = state.withLock { $0.loops[index].callbacks }
+		await callbacks.receive(frame)
+	}
+
+	func stopLoop(at index: Int) async {
+		let callbacks = state.withLock { state in
+			if state.loops[index].isActive {
+				state.loops[index].isActive = false
+				state.activeLoopCount -= 1
+			}
+			return state.loops[index].callbacks
+		}
+		await callbacks.didStop()
+	}
+}

--- a/Tests/NDITests/NDIPlayerTests.swift
+++ b/Tests/NDITests/NDIPlayerTests.swift
@@ -247,6 +247,44 @@ struct NDIPlayerTests {
 		await probe.stopLoop(at: 0)
 	}
 
+	@Test
+	func registeredStreamReceivesMarkerYieldedImmediatelyWithAnotherSubscriber() async throws {
+		let probe = ReceiveLoopProbe()
+		let player = NDIPlayer(
+			name: "Test",
+			capture: NDIFrameCapture { .none },
+			startReceiveLoop: probe.starter
+		)
+		let existingStream = await player.registeredFrames(bufferingPolicy: .bufferingNewest(1))
+		let stream = await player.registeredFrames(
+			bufferingPolicy: .bufferingNewest(1),
+			including: { frame in
+				if case .marker = frame {
+					return true
+				}
+				return false
+			}
+		)
+
+		let marker = try NDIFrameMarker(id: #require(UUID(uuidString: "99999999-8888-7777-6666-555555555555")))
+		await player.yieldMarker(marker)
+
+		var iterator = stream.makeAsyncIterator()
+		if case let .marker(receivedMarker)? = await iterator.next() {
+			#expect(receivedMarker == marker)
+		} else {
+			Issue.record("Expected the marker yielded immediately after registration")
+		}
+		#expect(await player.activeSubscriptionCount == 2)
+
+		let existingConsumer = consume(existingStream)
+		let consumer = consume(stream)
+		existingConsumer.cancel()
+		consumer.cancel()
+		await existingConsumer.value
+		await consumer.value
+	}
+
 	private func consume(_ stream: NDIPlayer.FrameStream) -> Task<Void, Never> {
 		Task {
 			for await _ in stream {}


### PR DESCRIPTION
## What changed

- retain the dynamic NDI library handle for the function-table lifetime
- initialize the NDI runtime once and destroy it before closing the library
- expose load/initialization failures through `NDI.sharedResult`
- enforce one receive loop per player while any subscribers exist
- wait for a canceled receive loop to stop before starting another
- remove stale cached-video replay for new subscribers
- add per-subscriber buffering policies and dropped-frame callbacks
- use low-latency buffering in `NDIView`

## Why

ISORecorder normally has recorder, preview, and audio-meter subscribers on the same NDI source. Registering each subscriber previously replaced the receive thread before the old blocking capture loop had stopped, allowing overlapping receiver access and out-of-order timestamps. The dynamic loader also closed its handle while retaining function pointers and never initialized/destroyed the NDI runtime.

## Impact

The existing `frames()` and `frames(bufferingNewest:)` APIs remain source-compatible. Recording clients can opt into a deeper bounded buffer and count evictions, while UI clients can use `.lowLatency`. A new `NDI.sharedResult` preserves the load failure instead of reducing it immediately to `nil`.

## Root cause

Receive-loop ownership was tied to every continuation update rather than the transition between zero and nonzero subscribers, and the dynamic library handle/runtime had no retained owner.

## Checks

- `swift test` (20 tests across 9 suites)
- `swift build -c release`
- SwiftFormat lint
- `git diff --check`
