### PR TITLE
Add configurable NDI receivers and sender support

### DIFF
--- a/Examples/SignalGenerator/SignalGenerator.xcodeproj/project.pbxproj
+++ b/Examples/SignalGenerator/SignalGenerator.xcodeproj/project.pbxproj
@@ -1,0 +1,395 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 90;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		000000000000000000000150 /* NDI in Frameworks */ = {isa = PBXBuildFile; productRef = 000000000000000000000152 /* NDI */; };
+		000000000000000000000155 /* libndi.dylib in Embed Libraries */ = {isa = PBXBuildFile; fileRef = 000000000000000000000154 /* libndi.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		000000000000000000000156 /* Embed Libraries */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				000000000000000000000155 /* libndi.dylib in Embed Libraries */,
+			);
+			name = "Embed Libraries";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		000000000000000000000120 /* SignalGenerator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SignalGenerator.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		000000000000000000000154 /* libndi.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libndi.dylib; path = "../../../../../../../Library/NDI SDK for Apple/lib/macOS/libndi.dylib"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		000000000000000000000010 /* SignalGenerator */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = SignalGenerator;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		000000000000000130000000 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			files = (
+				000000000000000000000150 /* NDI in Frameworks */,
+			);
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		000000000000000000000001 = {
+			isa = PBXGroup;
+			children = (
+				000000000000000000000010 /* SignalGenerator */,
+				000000000000000000000154 /* libndi.dylib */,
+				000000000000000000000020 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		000000000000000000000020 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				000000000000000000000120 /* SignalGenerator.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		000000000000000100000000 /* SignalGenerator */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 000000000000000110000000 /* Build configuration list for PBXNativeTarget "SignalGenerator" */;
+			buildPhases = (
+				000000000000000120000000 /* Sources */,
+				000000000000000130000000 /* Frameworks */,
+				000000000000000140000000 /* Resources */,
+				000000000000000000000156 /* Embed Libraries */,
+			);
+			buildRules = (
+			);
+			fileSystemSynchronizedGroups = (
+				000000000000000000000010 /* SignalGenerator */,
+			);
+			name = SignalGenerator;
+			packageProductDependencies = (
+				000000000000000000000152 /* NDI */,
+			);
+			productName = MyApp;
+			productReference = 000000000000000000000120 /* SignalGenerator.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		000000000000000000000000 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2630;
+				LastUpgradeCheck = 2700;
+				TargetAttributes = {
+					000000000000000100000000 = {
+						CreatedOnToolsVersion = 26.3;
+					};
+				};
+			};
+			buildConfigurationList = 000000000000000010000000 /* Build configuration list for PBXProject "SignalGenerator" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 000000000000000000000001;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 90;
+			productRefGroup = 000000000000000000000020 /* Products */;
+			packageReferences = (
+				000000000000000000000151 /* XCLocalSwiftPackageReference "../.." */,
+			);
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				000000000000000100000000 /* SignalGenerator */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		000000000000000140000000 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			files = (
+			);
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		000000000000000120000000 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			files = (
+			);
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		000000000000000011000000 /* Debug configuration for PBXProject "SignalGenerator" */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLETVOS_DEPLOYMENT_TARGET = 27.0;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DRIVERKIT_DEPLOYMENT_TARGET = 27.0;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 27.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 27.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PROJECT_UNIQUE_VALUE = LEQ23PK6;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				WATCHOS_DEPLOYMENT_TARGET = 27.0;
+				XROS_DEPLOYMENT_TARGET = 27.0;
+			};
+			name = Debug;
+		};
+		000000000000000012000000 /* Release configuration for PBXProject "SignalGenerator" */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLETVOS_DEPLOYMENT_TARGET = 27.0;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DRIVERKIT_DEPLOYMENT_TARGET = 27.0;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 27.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 27.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PROJECT_UNIQUE_VALUE = LEQ23PK6;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				WATCHOS_DEPLOYMENT_TARGET = 27.0;
+				XROS_DEPLOYMENT_TARGET = 27.0;
+			};
+			name = Release;
+		};
+		000000000000000111000000 /* Debug configuration for PBXNativeTarget "SignalGenerator" */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7TR2B85D62;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SELECTED_FILES = readonly;
+				GENERATE_INFOPLIST_FILE = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "devplaceholder.$(PROJECT_UNIQUE_VALUE:identifier).$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Debug;
+		};
+		000000000000000112000000 /* Release configuration for PBXNativeTarget "SignalGenerator" */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7TR2B85D62;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SELECTED_FILES = readonly;
+				GENERATE_INFOPLIST_FILE = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "devplaceholder.$(PROJECT_UNIQUE_VALUE:identifier).$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		000000000000000010000000 /* Build configuration list for PBXProject "SignalGenerator" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				000000000000000011000000 /* Debug configuration for PBXProject "SignalGenerator" */,
+				000000000000000012000000 /* Release configuration for PBXProject "SignalGenerator" */,
+			);
+			defaultConfigurationName = Release;
+		};
+		000000000000000110000000 /* Build configuration list for PBXNativeTarget "SignalGenerator" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				000000000000000111000000 /* Debug configuration for PBXNativeTarget "SignalGenerator" */,
+				000000000000000112000000 /* Release configuration for PBXNativeTarget "SignalGenerator" */,
+			);
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		000000000000000000000151 /* XCLocalSwiftPackageReference "../.." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../..;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		000000000000000000000152 /* NDI */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = NDI;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 000000000000000000000000 /* Project object */;
+}

--- a/Examples/SignalGenerator/SignalGenerator.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Examples/SignalGenerator/SignalGenerator.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Examples/SignalGenerator/SignalGenerator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/SignalGenerator/SignalGenerator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,69 @@
+{
+  "originHash" : "e95d4d9fe02f6ef3fff3479c09fd4303d2d3f1909859ea91d8bd859daa4d96ea",
+  "pins" : [
+    {
+      "identity" : "combine-schedulers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/combine-schedulers",
+      "state" : {
+        "revision" : "dcccb979a2183b8df3334237e3dc1ae2b4116a86",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "state" : {
+        "revision" : "72d749bf341b78851203066ab421869b783ec42a",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "5fa253428866f2360c3754e88537f700ed2656b5",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-dependencies",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-dependencies.git",
+      "state" : {
+        "revision" : "5e0815746534ccaa9e20588ea35d3bb2cb27bab8",
+        "version" : "1.17.0"
+      }
+    },
+    {
+      "identity" : "swift-issue-reporting",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-issue-reporting",
+      "state" : {
+        "revision" : "71c7c9a761d1ca6ed4ccb6ced040fe1c1a39e8e7",
+        "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "7bbd97af585672a3dcdf6575ad37b339ad41b579",
+        "version" : "1.13.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Examples/SignalGenerator/SignalGenerator/ContentView.swift
+++ b/Examples/SignalGenerator/SignalGenerator/ContentView.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+
+struct ContentView: View {
+	@Bindable var model: SignalGeneratorModel
+	@State private var inspectorPresented = true
+
+	var body: some View {
+		VStack(spacing: 0) {
+			preview
+			statusBar
+		}
+		.background(.black)
+		.inspector(isPresented: $inspectorPresented) {
+			SignalInspector(model: model)
+				.inspectorColumnWidth(min: 240, ideal: 280, max: 360)
+		}
+		.toolbar {
+			ToolbarItem {
+				Button(model.isSending ? "Stop" : "Start", systemImage: model.isSending ? "stop.fill" : "play.fill") {
+					model.toggleSending()
+				}
+				.help(model.isSending ? "Stop Sending" : "Start Sending")
+			}
+
+			ToolbarItem(placement: .primaryAction) {
+				Button("Inspector", systemImage: "sidebar.trailing") {
+					inspectorPresented.toggle()
+				}
+				.help(inspectorPresented ? "Hide Inspector" : "Show Inspector")
+				.accessibilityLabel(inspectorPresented ? "Hide Inspector" : "Show Inspector")
+			}
+		}
+		.onChange(of: model.configuration) {
+			model.restartIfSending()
+		}
+	}
+
+	private var preview: some View {
+		ZStack {
+			Color.black
+
+			if let image = model.preview {
+				Image(decorative: image, scale: 1)
+					.resizable()
+					.aspectRatio(contentMode: .fit)
+					.shadow(color: .black.opacity(0.5), radius: 20)
+					.padding(24)
+			} else {
+				ContentUnavailableView(
+					"Signal Preview",
+					systemImage: "waveform.path.ecg.rectangle",
+					description: Text("Start sending to generate an NDI test signal.")
+				)
+				.environment(\.colorScheme, .dark)
+			}
+		}
+		.frame(minWidth: 520, minHeight: 360)
+		.clipped()
+	}
+
+	private var statusBar: some View {
+		HStack(spacing: 8) {
+			Circle()
+				.fill(model.isSending ? Color.green : Color.secondary)
+				.frame(width: 7, height: 7)
+				.accessibilityHidden(true)
+			Text(model.status)
+				.lineLimit(1)
+			Spacer()
+			Text(model.frameLabel)
+				.monospacedDigit()
+			Divider().frame(height: 12)
+			Label("\(model.connectionCount)", systemImage: "display.2")
+				.help("Connected NDI receivers")
+		}
+		.font(.caption)
+		.foregroundStyle(.secondary)
+		.padding(.horizontal, 12)
+		.frame(height: 28)
+		.background(.bar)
+	}
+}
+
+private struct SignalInspector: View {
+	@Bindable var model: SignalGeneratorModel
+
+	var body: some View {
+		Form {
+			Section("NDI Source") {
+				TextField("Name", text: $model.configuration.sourceName)
+					.textFieldStyle(.roundedBorder)
+			}
+
+			Section("Video Format") {
+				Picker("Resolution", selection: $model.configuration.resolution) {
+					ForEach(SignalResolution.allCases) { resolution in
+						Text(resolution.rawValue).tag(resolution)
+					}
+				}
+				LabeledContent("Dimensions", value: model.configuration.resolution.dimensions)
+				Picker("Frame Rate", selection: $model.configuration.frameRate) {
+					ForEach(SignalFrameRate.allCases) { frameRate in
+						Text(frameRate.rawValue).tag(frameRate)
+					}
+				}
+			}
+
+			Section("Test Pattern") {
+				Picker("Pattern", selection: $model.configuration.pattern) {
+					ForEach(SignalPattern.allCases) { pattern in
+						Text(pattern.rawValue).tag(pattern)
+					}
+				}
+				Toggle("Show Source Name", isOn: $model.configuration.showSourceName)
+				Toggle("Show Signal Details", isOn: $model.configuration.showSignalDetails)
+			}
+		}
+		.formStyle(.grouped)
+		.toggleStyle(.checkbox)
+		.padding(.top, 4)
+	}
+}
+
+#Preview {
+	ContentView(model: SignalGeneratorModel())
+		.frame(width: 1_120, height: 720)
+}

--- a/Examples/SignalGenerator/SignalGenerator/ContentView.swift
+++ b/Examples/SignalGenerator/SignalGenerator/ContentView.swift
@@ -126,11 +126,6 @@ private struct SignalInspector: View {
 			Section("Audio") {
 				Toggle("Send Sine Tone", isOn: $model.configuration.sendsAudio)
 				Group {
-					Picker("API", selection: $model.configuration.audioVersion) {
-						ForEach(SignalAudioVersion.allCases) { version in
-							Text(version.rawValue).tag(version)
-						}
-					}
 					Picker("Channels", selection: $model.configuration.audioChannels) {
 						ForEach(SignalAudioChannels.allCases) { channels in
 							Text(channels.rawValue).tag(channels)

--- a/Examples/SignalGenerator/SignalGenerator/ContentView.swift
+++ b/Examples/SignalGenerator/SignalGenerator/ContentView.swift
@@ -1,3 +1,4 @@
+import NDI
 import SwiftUI
 
 struct ContentView: View {
@@ -70,6 +71,13 @@ struct ContentView: View {
 			Text(model.frameLabel)
 				.monospacedDigit()
 			Divider().frame(height: 12)
+			if model.tally.isOnProgram {
+				Label("Program", systemImage: "circle.fill")
+					.foregroundStyle(.red)
+			} else if model.tally.isOnPreview {
+				Label("Preview", systemImage: "circle.fill")
+					.foregroundStyle(.green)
+			}
 			Label("\(model.connectionCount)", systemImage: "display.2")
 				.help("Connected NDI receivers")
 		}
@@ -113,6 +121,69 @@ private struct SignalInspector: View {
 				}
 				Toggle("Show Source Name", isOn: $model.configuration.showSourceName)
 				Toggle("Show Signal Details", isOn: $model.configuration.showSignalDetails)
+			}
+
+			Section("Audio") {
+				Toggle("Send Sine Tone", isOn: $model.configuration.sendsAudio)
+				Group {
+					Picker("API", selection: $model.configuration.audioVersion) {
+						ForEach(SignalAudioVersion.allCases) { version in
+							Text(version.rawValue).tag(version)
+						}
+					}
+					Picker("Channels", selection: $model.configuration.audioChannels) {
+						ForEach(SignalAudioChannels.allCases) { channels in
+							Text(channels.rawValue).tag(channels)
+						}
+					}
+					Picker("Sample Rate", selection: $model.configuration.audioSampleRate) {
+						ForEach(SignalAudioSampleRate.allCases) { sampleRate in
+							Text(sampleRate.rawValue).tag(sampleRate)
+						}
+					}
+					Stepper(value: $model.configuration.toneFrequency, in: 100 ... 2000, step: 10) {
+						LabeledContent("Frequency", value: "\(model.configuration.toneFrequency.formatted()) Hz")
+					}
+					Stepper(value: $model.configuration.toneLevel, in: -60 ... 0, step: 1) {
+						LabeledContent("Level", value: "\(model.configuration.toneLevel.formatted()) dB")
+					}
+				}
+				.disabled(!model.configuration.sendsAudio)
+			}
+
+			Section("Metadata") {
+				Toggle("Send Every Second", isOn: $model.configuration.sendsMetadata)
+				TextField("Frame XML", text: $model.configuration.metadata, axis: .vertical)
+					.lineLimit(2 ... 4)
+					.disabled(!model.configuration.sendsMetadata)
+				Toggle("Send On Connection", isOn: $model.configuration.sendsConnectionMetadata)
+				TextField("Connection XML", text: $model.configuration.connectionMetadata, axis: .vertical)
+					.lineLimit(2 ... 4)
+					.disabled(!model.configuration.sendsConnectionMetadata)
+			}
+
+			Section("Failover") {
+				Toggle("Use Failover Source", isOn: $model.configuration.usesFailover)
+				Group {
+					TextField("Name", text: $model.configuration.failoverName)
+					TextField("URL", text: $model.configuration.failoverURL)
+				}
+				.disabled(!model.configuration.usesFailover)
+			}
+
+			Section("Receiver Feedback") {
+				LabeledContent("Connections", value: "\(model.connectionCount)")
+				LabeledContent("Program", value: model.tally.isOnProgram ? "On" : "Off")
+				LabeledContent("Preview", value: model.tally.isOnPreview ? "On" : "Off")
+				LabeledContent("Audio Samples", value: model.audioSamplesSent.formatted())
+				LabeledContent("Metadata Frames", value: model.metadataFramesSent.formatted())
+				if let metadata = model.lastReceivedMetadata {
+					LabeledContent("Received Metadata") {
+						Text(metadata)
+							.font(.caption)
+							.textSelection(.enabled)
+					}
+				}
 			}
 		}
 		.formStyle(.grouped)

--- a/Examples/SignalGenerator/SignalGenerator/SignalAudioGenerator.swift
+++ b/Examples/SignalGenerator/SignalGenerator/SignalAudioGenerator.swift
@@ -1,0 +1,32 @@
+import Foundation
+import NDI
+
+nonisolated struct SignalAudioGenerator {
+	private var sampleIndex: Int64 = 0
+	private var sampleRemainder: Int64 = 0
+
+	mutating func makeFrame(
+		configuration: SignalConfiguration,
+		timecode: NDITimecode
+	) throws -> NDISendAudioFrame {
+		let sampleRate = configuration.audioSampleRate.value
+		let scaledSamples = Int64(sampleRate) * Int64(configuration.frameRate.denominator) + sampleRemainder
+		let numberOfSamples = Int(scaledSamples / Int64(configuration.frameRate.numerator))
+		sampleRemainder = scaledSamples % Int64(configuration.frameRate.numerator)
+
+		let amplitude = pow(10, configuration.toneLevel / 20)
+		let angularFrequency = 2 * Double.pi * configuration.toneFrequency
+		let samples = (0 ..< numberOfSamples).map { offset in
+			let time = Double(sampleIndex + Int64(offset)) / Double(sampleRate)
+			return Float(sin(angularFrequency * time) * amplitude)
+		}
+		sampleIndex += Int64(numberOfSamples)
+
+		return try NDISendAudioFrame(
+			planarSamples: Array(repeating: samples, count: configuration.audioChannels.count),
+			sampleRate: sampleRate,
+			timecode: timecode,
+			metadata: #"<audio_source name="Sine Tone"/>"#
+		)
+	}
+}

--- a/Examples/SignalGenerator/SignalGenerator/SignalConfiguration.swift
+++ b/Examples/SignalGenerator/SignalGenerator/SignalConfiguration.swift
@@ -1,5 +1,6 @@
 import CoreGraphics
 import CoreMedia
+import NDI
 
 nonisolated struct SignalConfiguration: Equatable, Sendable {
 	var sourceName = "Signal Generator"
@@ -8,6 +9,19 @@ nonisolated struct SignalConfiguration: Equatable, Sendable {
 	var pattern = SignalPattern.colorBars
 	var showSourceName = true
 	var showSignalDetails = true
+	var sendsAudio = true
+	var audioVersion = SignalAudioVersion.v3
+	var audioChannels = SignalAudioChannels.stereo
+	var audioSampleRate = SignalAudioSampleRate.hz48000
+	var toneFrequency = 440.0
+	var toneLevel = -20.0
+	var sendsMetadata = true
+	var metadata = #"<signal_generator event="heartbeat"/>"#
+	var sendsConnectionMetadata = true
+	var connectionMetadata = #"<ndi_product long_name="swift-ndi Signal Generator" short_name="Signal Generator" manufacturer="swift-ndi" version="1.0" session="default" model_name="SignalGenerator" serial=""/>"#
+	var usesFailover = false
+	var failoverName = ""
+	var failoverURL = ""
 }
 
 nonisolated enum SignalResolution: String, CaseIterable, Identifiable, Sendable {
@@ -92,4 +106,48 @@ nonisolated enum SignalPattern: String, CaseIterable, Identifiable, Sendable {
 	case checkerboard = "Checkerboard"
 
 	var id: Self { self }
+}
+
+nonisolated enum SignalAudioVersion: String, CaseIterable, Identifiable, Sendable {
+	case v2 = "Audio v2"
+	case v3 = "Audio v3"
+
+	var id: Self { self }
+
+	var ndiVersion: NDISendAudioFrame.Version {
+		switch self {
+		case .v2: .v2
+		case .v3: .v3
+		}
+	}
+}
+
+nonisolated enum SignalAudioChannels: String, CaseIterable, Identifiable, Sendable {
+	case mono = "Mono"
+	case stereo = "Stereo"
+
+	var id: Self { self }
+
+	var count: Int {
+		switch self {
+		case .mono: 1
+		case .stereo: 2
+		}
+	}
+}
+
+nonisolated enum SignalAudioSampleRate: String, CaseIterable, Identifiable, Sendable {
+	case hz44100 = "44.1 kHz"
+	case hz48000 = "48 kHz"
+	case hz96000 = "96 kHz"
+
+	var id: Self { self }
+
+	var value: Int {
+		switch self {
+		case .hz44100: 44100
+		case .hz48000: 48000
+		case .hz96000: 96000
+		}
+	}
 }

--- a/Examples/SignalGenerator/SignalGenerator/SignalConfiguration.swift
+++ b/Examples/SignalGenerator/SignalGenerator/SignalConfiguration.swift
@@ -1,6 +1,5 @@
 import CoreGraphics
 import CoreMedia
-import NDI
 
 nonisolated struct SignalConfiguration: Equatable, Sendable {
 	var sourceName = "Signal Generator"
@@ -10,7 +9,6 @@ nonisolated struct SignalConfiguration: Equatable, Sendable {
 	var showSourceName = true
 	var showSignalDetails = true
 	var sendsAudio = true
-	var audioVersion = SignalAudioVersion.v3
 	var audioChannels = SignalAudioChannels.stereo
 	var audioSampleRate = SignalAudioSampleRate.hz48000
 	var toneFrequency = 440.0
@@ -106,20 +104,6 @@ nonisolated enum SignalPattern: String, CaseIterable, Identifiable, Sendable {
 	case checkerboard = "Checkerboard"
 
 	var id: Self { self }
-}
-
-nonisolated enum SignalAudioVersion: String, CaseIterable, Identifiable, Sendable {
-	case v2 = "Audio v2"
-	case v3 = "Audio v3"
-
-	var id: Self { self }
-
-	var ndiVersion: NDISendAudioFrame.Version {
-		switch self {
-		case .v2: .v2
-		case .v3: .v3
-		}
-	}
 }
 
 nonisolated enum SignalAudioChannels: String, CaseIterable, Identifiable, Sendable {

--- a/Examples/SignalGenerator/SignalGenerator/SignalConfiguration.swift
+++ b/Examples/SignalGenerator/SignalGenerator/SignalConfiguration.swift
@@ -1,0 +1,95 @@
+import CoreGraphics
+import CoreMedia
+
+nonisolated struct SignalConfiguration: Equatable, Sendable {
+	var sourceName = "Signal Generator"
+	var resolution = SignalResolution.fullHD
+	var frameRate = SignalFrameRate.fps30
+	var pattern = SignalPattern.colorBars
+	var showSourceName = true
+	var showSignalDetails = true
+}
+
+nonisolated enum SignalResolution: String, CaseIterable, Identifiable, Sendable {
+	case hd = "HD 720p"
+	case fullHD = "Full HD 1080p"
+	case fullHDVertical = "1080 × 1920 (Vertical)"
+	case fullHDSquare = "1080 × 1080 (Square)"
+	case ultraHD = "Ultra HD 2160p"
+
+	var id: Self { self }
+
+	var width: Int {
+		switch self {
+		case .hd: 1_280
+		case .fullHD: 1_920
+		case .fullHDVertical, .fullHDSquare: 1_080
+		case .ultraHD: 3_840
+		}
+	}
+
+	var height: Int {
+		switch self {
+		case .hd: 720
+		case .fullHD, .fullHDSquare: 1_080
+		case .fullHDVertical: 1_920
+		case .ultraHD: 2_160
+		}
+	}
+
+	var dimensions: String { "\(width) × \(height)" }
+	var size: CGSize { CGSize(width: width, height: height) }
+}
+
+nonisolated enum SignalFrameRate: String, CaseIterable, Identifiable, Sendable {
+	case fps2398 = "23.98 fps"
+	case fps24 = "24 fps"
+	case fps25 = "25 fps"
+	case fps2997 = "29.97 fps"
+	case fps30 = "30 fps"
+	case fps50 = "50 fps"
+	case fps5994 = "59.94 fps"
+	case fps60 = "60 fps"
+
+	var id: Self { self }
+
+	var numerator: Int32 {
+		switch self {
+		case .fps2398: 24_000
+		case .fps24: 24
+		case .fps25: 25
+		case .fps2997: 30_000
+		case .fps30: 30
+		case .fps50: 50
+		case .fps5994: 60_000
+		case .fps60: 60
+		}
+	}
+
+	var denominator: Int32 {
+		switch self {
+		case .fps2398, .fps2997, .fps5994: 1_001
+		default: 1
+		}
+	}
+
+	var framesPerSecond: Double { Double(numerator) / Double(denominator) }
+	var nominalFramesPerSecond: Int { Int(framesPerSecond.rounded()) }
+	var counterLabel: String {
+		switch self {
+		case .fps2398: "23.98"
+		case .fps2997: "29.97"
+		case .fps5994: "59.94"
+		default: "\(nominalFramesPerSecond)"
+		}
+	}
+	var mediaTime: CMTime { CMTime(value: Int64(numerator), timescale: denominator) }
+}
+
+nonisolated enum SignalPattern: String, CaseIterable, Identifiable, Sendable {
+	case colorBars = "Color Bars"
+	case grayscale = "Grayscale"
+	case checkerboard = "Checkerboard"
+
+	var id: Self { self }
+}

--- a/Examples/SignalGenerator/SignalGenerator/SignalFrameRenderer.swift
+++ b/Examples/SignalGenerator/SignalGenerator/SignalFrameRenderer.swift
@@ -1,0 +1,164 @@
+import CoreGraphics
+import CoreText
+import CoreVideo
+import Foundation
+
+nonisolated enum SignalFrameRendererError: Error {
+	case couldNotCreatePixelBuffer(CVReturn)
+	case couldNotLockPixelBuffer(CVReturn)
+	case missingPixelBufferBaseAddress
+	case couldNotCreateContext
+	case couldNotCreateImage
+}
+
+nonisolated struct RenderedSignalFrame: @unchecked Sendable {
+	let pixelBuffer: CVPixelBuffer
+	let image: CGImage
+}
+
+nonisolated enum SignalFrameRenderer {
+	static func render(
+		configuration: SignalConfiguration,
+		date: Date,
+		frameInSecond: Int
+	) throws -> RenderedSignalFrame {
+		let width = configuration.resolution.width
+		let height = configuration.resolution.height
+		var pixelBuffer: CVPixelBuffer?
+		let createResult = CVPixelBufferCreate(
+			kCFAllocatorDefault,
+			width,
+			height,
+			kCVPixelFormatType_32BGRA,
+			[
+				kCVPixelBufferCGImageCompatibilityKey: true,
+				kCVPixelBufferCGBitmapContextCompatibilityKey: true,
+			] as CFDictionary,
+			&pixelBuffer
+		)
+		guard createResult == kCVReturnSuccess, let pixelBuffer else {
+			throw SignalFrameRendererError.couldNotCreatePixelBuffer(createResult)
+		}
+
+		let lockResult = CVPixelBufferLockBaseAddress(pixelBuffer, [])
+		guard lockResult == kCVReturnSuccess else {
+			throw SignalFrameRendererError.couldNotLockPixelBuffer(lockResult)
+		}
+		defer { CVPixelBufferUnlockBaseAddress(pixelBuffer, []) }
+
+		guard let baseAddress = CVPixelBufferGetBaseAddress(pixelBuffer) else {
+			throw SignalFrameRendererError.missingPixelBufferBaseAddress
+		}
+		guard let context = CGContext(
+			data: baseAddress,
+			width: width,
+			height: height,
+			bitsPerComponent: 8,
+			bytesPerRow: CVPixelBufferGetBytesPerRow(pixelBuffer),
+			space: CGColorSpaceCreateDeviceRGB(),
+			bitmapInfo: CGBitmapInfo.byteOrder32Little.rawValue | CGImageAlphaInfo.premultipliedFirst.rawValue
+		) else {
+			throw SignalFrameRendererError.couldNotCreateContext
+		}
+
+		let bounds = CGRect(x: 0, y: 0, width: width, height: height)
+		drawPattern(configuration.pattern, in: bounds, context: context)
+		drawSafeArea(in: bounds, context: context)
+
+		let clock = systemTimeString(for: date)
+		let counter = String(format: "%02d", frameInSecond) + " / " + configuration.frameRate.counterLabel
+		let scale = CGFloat(height) / 1_080
+		drawCentered(clock, y: CGFloat(height) * 0.55, size: 122 * scale, context: context)
+		drawCentered(counter, y: CGFloat(height) * 0.40, size: 68 * scale, context: context)
+
+		if configuration.showSourceName {
+			drawLabel(configuration.sourceName, at: CGPoint(x: 48 * scale, y: CGFloat(height) - 78 * scale), size: 30 * scale, context: context)
+		}
+		if configuration.showSignalDetails {
+			let details = "\(configuration.resolution.dimensions)   •   \(configuration.frameRate.rawValue)"
+			drawLabel(details, at: CGPoint(x: 48 * scale, y: 48 * scale), size: 25 * scale, context: context)
+		}
+
+		guard let image = context.makeImage() else {
+			throw SignalFrameRendererError.couldNotCreateImage
+		}
+		return RenderedSignalFrame(pixelBuffer: pixelBuffer, image: image)
+	}
+
+	private static func drawPattern(_ pattern: SignalPattern, in bounds: CGRect, context: CGContext) {
+		switch pattern {
+		case .colorBars:
+			let colors: [CGColor] = [
+				CGColor(red: 0.75, green: 0.75, blue: 0.75, alpha: 1),
+				CGColor(red: 0.75, green: 0.75, blue: 0, alpha: 1),
+				CGColor(red: 0, green: 0.75, blue: 0.75, alpha: 1),
+				CGColor(red: 0, green: 0.75, blue: 0, alpha: 1),
+				CGColor(red: 0.75, green: 0, blue: 0.75, alpha: 1),
+				CGColor(red: 0.75, green: 0, blue: 0, alpha: 1),
+				CGColor(red: 0, green: 0, blue: 0.75, alpha: 1),
+			]
+			let barWidth = bounds.width / CGFloat(colors.count)
+			for (index, color) in colors.enumerated() {
+				context.setFillColor(color)
+				context.fill(CGRect(x: CGFloat(index) * barWidth, y: 0, width: barWidth + 1, height: bounds.height))
+			}
+		case .grayscale:
+			let colors = (0..<10).map { CGFloat($0) / 9 }
+			let barWidth = bounds.width / CGFloat(colors.count)
+			for (index, white) in colors.enumerated() {
+				context.setFillColor(CGColor(gray: white, alpha: 1))
+				context.fill(CGRect(x: CGFloat(index) * barWidth, y: 0, width: barWidth + 1, height: bounds.height))
+			}
+		case .checkerboard:
+			let cell = bounds.height / 8
+			for row in 0..<8 {
+				for column in 0..<Int(ceil(bounds.width / cell)) {
+					let white: CGFloat = (row + column).isMultiple(of: 2) ? 0.72 : 0.12
+					context.setFillColor(CGColor(gray: white, alpha: 1))
+					context.fill(CGRect(x: CGFloat(column) * cell, y: CGFloat(row) * cell, width: cell, height: cell))
+				}
+			}
+		}
+	}
+
+	private static func drawSafeArea(in bounds: CGRect, context: CGContext) {
+		context.saveGState()
+		context.setStrokeColor(CGColor(gray: 1, alpha: 0.3))
+		context.setLineWidth(max(2, bounds.height / 540))
+		context.stroke(bounds.insetBy(dx: bounds.width * 0.05, dy: bounds.height * 0.05))
+		context.restoreGState()
+	}
+
+	private static func drawCentered(_ text: String, y: CGFloat, size: CGFloat, context: CGContext) {
+		let line = makeLine(text, size: size)
+		let lineBounds = CTLineGetBoundsWithOptions(line, [.useOpticalBounds])
+		context.saveGState()
+		context.setShadow(offset: .zero, blur: size * 0.12, color: CGColor(gray: 0, alpha: 0.9))
+		context.textPosition = CGPoint(x: (CGFloat(context.width) - lineBounds.width) / 2 - lineBounds.minX, y: y)
+		CTLineDraw(line, context)
+		context.restoreGState()
+	}
+
+	private static func drawLabel(_ text: String, at point: CGPoint, size: CGFloat, context: CGContext) {
+		let line = makeLine(text, size: size)
+		context.saveGState()
+		context.setShadow(offset: .zero, blur: size * 0.1, color: CGColor(gray: 0, alpha: 0.9))
+		context.textPosition = point
+		CTLineDraw(line, context)
+		context.restoreGState()
+	}
+
+	private static func makeLine(_ text: String, size: CGFloat) -> CTLine {
+		let font = CTFontCreateWithName("SFMono-Bold" as CFString, size, nil)
+		let attributes: [NSAttributedString.Key: Any] = [
+			NSAttributedString.Key(kCTFontAttributeName as String): font,
+			NSAttributedString.Key(kCTForegroundColorAttributeName as String): CGColor(gray: 1, alpha: 1),
+		]
+		return CTLineCreateWithAttributedString(NSAttributedString(string: text, attributes: attributes))
+	}
+
+	private static func systemTimeString(for date: Date) -> String {
+		let components = Calendar.autoupdatingCurrent.dateComponents([.hour, .minute, .second], from: date)
+		return String(format: "%02d:%02d:%02d", components.hour ?? 0, components.minute ?? 0, components.second ?? 0)
+	}
+}

--- a/Examples/SignalGenerator/SignalGenerator/SignalGeneratorApp.swift
+++ b/Examples/SignalGenerator/SignalGenerator/SignalGeneratorApp.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+@main
+struct SignalGeneratorApp: App {
+	@State private var model = SignalGeneratorModel()
+
+	var body: some Scene {
+		Window("Signal Generator", id: "signal-generator") {
+			ContentView(model: model)
+		}
+		.defaultSize(width: 1_120, height: 720)
+		.commands {
+			CommandMenu("Signal") {
+				Button(model.isSending ? "Stop Sending" : "Start Sending") {
+					model.toggleSending()
+				}
+				.keyboardShortcut(.space, modifiers: [])
+			}
+		}
+	}
+}

--- a/Examples/SignalGenerator/SignalGenerator/SignalGeneratorModel.swift
+++ b/Examples/SignalGenerator/SignalGenerator/SignalGeneratorModel.swift
@@ -95,7 +95,7 @@ final class SignalGeneratorModel {
 
 					if configuration.sendsAudio {
 						let audioFrame = try audioGenerator.makeFrame(configuration: configuration, timecode: timecode)
-						sender.send(audioFrame, version: configuration.audioVersion.ndiVersion)
+						sender.send(audioFrame)
 						audioSamplesSent += audioFrame.numberOfSamples
 					}
 

--- a/Examples/SignalGenerator/SignalGenerator/SignalGeneratorModel.swift
+++ b/Examples/SignalGenerator/SignalGenerator/SignalGeneratorModel.swift
@@ -1,0 +1,134 @@
+import CoreGraphics
+import Foundation
+import NDI
+import Observation
+
+@MainActor
+@Observable
+final class SignalGeneratorModel {
+	var configuration = SignalConfiguration()
+	private(set) var isSending = false
+	private(set) var preview: CGImage?
+	private(set) var frameLabel = "— / —"
+	private(set) var connectionCount = 0
+	private(set) var status = "Ready"
+
+	private var sendTask: Task<Void, Never>?
+	private var generation: UUID?
+
+	func toggleSending() {
+		isSending ? stop() : start()
+	}
+
+	func start() {
+		guard !isSending else { return }
+		isSending = true
+		status = "Starting…"
+		launch(configuration: configuration, after: nil)
+	}
+
+	private func launch(configuration: SignalConfiguration, after previousTask: Task<Void, Never>?) {
+		let generation = UUID()
+		self.generation = generation
+
+		sendTask = Task.detached(priority: .userInitiated) { [weak self] in
+			await previousTask?.value
+			guard !Task.isCancelled else { return }
+			guard let sender = NDISender(name: configuration.sourceName) else {
+				await self?.finish(generation: generation, with: "NDI runtime unavailable")
+				return
+			}
+
+			let clock = ContinuousClock()
+			let interval = Duration.seconds(1 / configuration.frameRate.framesPerSecond)
+			var deadline = clock.now
+			var second = Int(Date().timeIntervalSince1970)
+			var frameInSecond = 0
+
+			await self?.setStatus(
+				"Sending as \(sender.sourceName() ?? configuration.sourceName)",
+				generation: generation
+			)
+
+			do {
+				while !Task.isCancelled {
+					let now = Date()
+					let currentSecond = Int(now.timeIntervalSince1970)
+					if currentSecond != second {
+						second = currentSecond
+						frameInSecond = 0
+					}
+					frameInSecond += 1
+
+					let rendered = try SignalFrameRenderer.render(
+						configuration: configuration,
+						date: now,
+						frameInSecond: frameInSecond
+					)
+					let frame = try NDISendVideoFrame(
+						pixelBuffer: rendered.pixelBuffer,
+						frameRate: configuration.frameRate.mediaTime
+					)
+					try sender.send(frame)
+
+					let label = "\(frameInSecond) / \(configuration.frameRate.counterLabel)"
+					let connections = sender.connectionCount()
+					await self?.didSend(
+						preview: rendered.image,
+						frameLabel: label,
+						connections: connections,
+						generation: generation
+					)
+
+					deadline += interval
+					if deadline < clock.now {
+						deadline = clock.now
+					}
+					try await clock.sleep(until: deadline)
+				}
+			} catch is CancellationError {
+				// Stopping is the normal cancellation path.
+			} catch {
+				await self?.finish(generation: generation, with: error.localizedDescription)
+			}
+		}
+	}
+
+	func stop() {
+		sendTask?.cancel()
+		sendTask = nil
+		generation = nil
+		isSending = false
+		connectionCount = 0
+		status = "Stopped"
+	}
+
+	func restartIfSending() {
+		guard isSending else { return }
+		let previousTask = sendTask
+		previousTask?.cancel()
+		status = "Updating…"
+		launch(configuration: configuration, after: previousTask)
+	}
+
+	private func didSend(preview: CGImage, frameLabel: String, connections: Int, generation: UUID) {
+		guard self.generation == generation else { return }
+		self.preview = preview
+		self.frameLabel = frameLabel
+		connectionCount = connections
+	}
+
+	private func setStatus(_ status: String, generation: UUID) {
+		guard self.generation == generation else { return }
+		self.status = status
+	}
+
+	private func finish(generation: UUID, with status: String) {
+		guard self.generation == generation else { return }
+		sendTask = nil
+		self.generation = nil
+		isSending = false
+		connectionCount = 0
+		self.status = status
+	}
+}

--- a/Examples/SignalGenerator/SignalGenerator/SignalGeneratorModel.swift
+++ b/Examples/SignalGenerator/SignalGenerator/SignalGeneratorModel.swift
@@ -12,6 +12,10 @@ final class SignalGeneratorModel {
 	private(set) var frameLabel = "— / —"
 	private(set) var connectionCount = 0
 	private(set) var status = "Ready"
+	private(set) var tally = NDISenderTally(isOnProgram: false, isOnPreview: false)
+	private(set) var lastReceivedMetadata: String?
+	private(set) var audioSamplesSent = 0
+	private(set) var metadataFramesSent = 0
 
 	private var sendTask: Task<Void, Never>?
 	private var generation: UUID?
@@ -44,6 +48,22 @@ final class SignalGeneratorModel {
 			var deadline = clock.now
 			var second = Int(Date().timeIntervalSince1970)
 			var frameInSecond = 0
+			var audioGenerator = SignalAudioGenerator()
+			var audioSamplesSent = 0
+			var metadataFramesSent = 0
+			var lastMetadataSecond: Int?
+			var tally = NDISenderTally(isOnProgram: false, isOnPreview: false)
+			var lastReceivedMetadata: String?
+
+			sender.clearConnectionMetadata()
+			if configuration.sendsConnectionMetadata {
+				sender.addConnectionMetadata(.init(value: configuration.connectionMetadata))
+			}
+			if configuration.usesFailover {
+				sender.setFailoverSource(.init(name: configuration.failoverName, url: configuration.failoverURL))
+			} else {
+				sender.setFailoverSource(nil)
+			}
 
 			await self?.setStatus(
 				"Sending as \(sender.sourceName() ?? configuration.sourceName)",
@@ -59,6 +79,7 @@ final class SignalGeneratorModel {
 						frameInSecond = 0
 					}
 					frameInSecond += 1
+					let timecode = NDITimecode.now
 
 					let rendered = try SignalFrameRenderer.render(
 						configuration: configuration,
@@ -67,9 +88,29 @@ final class SignalGeneratorModel {
 					)
 					let frame = try NDISendVideoFrame(
 						pixelBuffer: rendered.pixelBuffer,
-						frameRate: configuration.frameRate.mediaTime
+						frameRate: configuration.frameRate.mediaTime,
+						timecode: timecode
 					)
 					try sender.send(frame)
+
+					if configuration.sendsAudio {
+						let audioFrame = try audioGenerator.makeFrame(configuration: configuration, timecode: timecode)
+						sender.send(audioFrame, version: configuration.audioVersion.ndiVersion)
+						audioSamplesSent += audioFrame.numberOfSamples
+					}
+
+					if configuration.sendsMetadata, lastMetadataSecond != currentSecond {
+						sender.send(.init(value: configuration.metadata, timecode: timecode))
+						metadataFramesSent += 1
+						lastMetadataSecond = currentSecond
+					}
+
+					if let tallyUpdate = sender.tally() {
+						tally = tallyUpdate
+					}
+					if case let .metadata(metadata) = sender.capture() {
+						lastReceivedMetadata = metadata.value
+					}
 
 					let label = "\(frameInSecond) / \(configuration.frameRate.counterLabel)"
 					let connections = sender.connectionCount()
@@ -77,6 +118,10 @@ final class SignalGeneratorModel {
 						preview: rendered.image,
 						frameLabel: label,
 						connections: connections,
+						tally: tally,
+						lastReceivedMetadata: lastReceivedMetadata,
+						audioSamplesSent: audioSamplesSent,
+						metadataFramesSent: metadataFramesSent,
 						generation: generation
 					)
 
@@ -100,6 +145,7 @@ final class SignalGeneratorModel {
 		generation = nil
 		isSending = false
 		connectionCount = 0
+		tally = NDISenderTally(isOnProgram: false, isOnPreview: false)
 		status = "Stopped"
 	}
 
@@ -111,11 +157,24 @@ final class SignalGeneratorModel {
 		launch(configuration: configuration, after: previousTask)
 	}
 
-	private func didSend(preview: CGImage, frameLabel: String, connections: Int, generation: UUID) {
+	private func didSend(
+		preview: CGImage,
+		frameLabel: String,
+		connections: Int,
+		tally: NDISenderTally,
+		lastReceivedMetadata: String?,
+		audioSamplesSent: Int,
+		metadataFramesSent: Int,
+		generation: UUID
+	) {
 		guard self.generation == generation else { return }
 		self.preview = preview
 		self.frameLabel = frameLabel
 		connectionCount = connections
+		self.tally = tally
+		self.lastReceivedMetadata = lastReceivedMetadata
+		self.audioSamplesSent = audioSamplesSent
+		self.metadataFramesSent = metadataFramesSent
 	}
 
 	private func setStatus(_ status: String, generation: UUID) {
@@ -129,6 +188,7 @@ final class SignalGeneratorModel {
 		self.generation = nil
 		isSending = false
 		connectionCount = 0
+		tally = NDISenderTally(isOnProgram: false, isOnPreview: false)
 		self.status = status
 	}
 }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,31 @@
 # swift-ndi
 
 A memory-safe, type-safe, and concurrency-safe Swift wrapper for the [NDI SDK](https://docs.ndi.video/all/developing-with-ndi/sdk).
+
+## NDI SDK and runtime setup
+
+This package provides a Swift interface to NDI, but does not redistribute the NDI SDK headers or binary. Install the NDI SDK for Apple before building, and review NDI's [software distribution requirements](https://docs.ndi.video/all/developing-with-ndi/sdk/software-distribution) before shipping its libraries with an application.
+
+### iOS and tvOS
+
+NDI must be statically linked on iOS and tvOS. Add the SDK's platform-specific static library (`libndi_ios.a` or `libndi_tvos.a`) to the application target that consumes the `NDI` product. These platforms do not load the NDI runtime dynamically.
+
+### macOS
+
+On macOS, the package loads `libndi.dylib` at runtime. For an application bundle, the recommended setup is to embed the library in the app:
+
+1. Add the NDI SDK's `libndi.dylib` to the application target.
+2. Embed it at `Contents/Frameworks/libndi.dylib` using a Copy Files build phase whose destination is **Frameworks**, with **Code Sign on Copy** enabled.
+3. Keep `@executable_path/../Frameworks` in the target's Runpath Search Paths. This is included in Xcode's usual application defaults.
+
+Embedding gives the application a known runtime version and works with the Hardened Runtime and App Sandbox, which may prevent access to libraries installed elsewhere on the system. Ensure that distributing the embedded library complies with the NDI SDK license.
+
+The loader checks the following locations, in order:
+
+1. `@executable_path/../Frameworks/libndi.dylib`
+2. The directory named by `NDI_RUNTIME_DIR_V6`
+3. `/Library/NDI SDK for Apple/lib/macOS/libndi.dylib`
+4. `/usr/local/lib/libndi.dylib`
+5. `libndi.dylib` through the normal dyld search paths
+
+The installed paths and `NDI_RUNTIME_DIR_V6` are useful for development tools and non-sandboxed executables, but applications should not depend on an end user having the SDK or redistributable installed system-wide. See NDI's [Dynamic Loading of NDI Libraries](https://docs.ndi.video/all/developing-with-ndi/sdk/dynamic-loading-of-ndi-libraries) documentation for the official runtime-loading guidance.

--- a/Sources/NDI/NDI.swift
+++ b/Sources/NDI/NDI.swift
@@ -219,9 +219,15 @@ public extension NDI {
 			self.init(lib, retaining: runtime)
 		}
 
+		static let libraryPaths = [
+			"@executable_path/../Frameworks/libndi.dylib",
+			"libndi.dylib",
+			"/usr/local/lib/libndi.dylib",
+		]
+
 		static let sharedResult: Result<NDI, NDILoadError> = {
 			var lastError = NDILoadError.dlopenFailed(nil)
-			for path in ["libndi.dylib", "/usr/local/lib/libndi.dylib"] {
+			for path in libraryPaths {
 				do {
 					return try .success(NDI(libraryPath: path))
 				} catch {

--- a/Sources/NDI/NDI.swift
+++ b/Sources/NDI/NDI.swift
@@ -45,6 +45,18 @@ public struct NDI: Sendable {
 	var NDIlib_recv_free_audio_v3: @Sendable (NDIlib_recv_instance_t?, UnsafePointer<NDIlib_audio_frame_v3_t>?) -> Void
 
 	var NDIlib_recv_free_metadata: @Sendable (NDIlib_recv_instance_t?, UnsafePointer<NDIlib_metadata_frame_t>?) -> Void
+
+	// MARK: - SEND
+
+	var NDIlib_send_create: @Sendable (UnsafePointer<NDIlib_send_create_t>?) -> NDIlib_send_instance_t?
+
+	var NDIlib_send_destroy: @Sendable (NDIlib_send_instance_t?) -> Void
+
+	var NDIlib_send_send_video_v2: @Sendable (NDIlib_send_instance_t?, UnsafePointer<NDIlib_video_frame_v2_t>?) -> Void
+
+	var NDIlib_send_get_no_connections: @Sendable (NDIlib_send_instance_t?, UInt32) -> Int32 = { _, _ in 0 }
+
+	var NDIlib_send_get_source_name: @Sendable (NDIlib_send_instance_t?) -> UnsafePointer<NDIlib_source_t>?
 }
 
 public enum NDILoadError: Error, Equatable, LocalizedError, Sendable {
@@ -139,7 +151,13 @@ public extension NDI {
 			NDIlib_recv_capture_v3: { lib.NDIlib_recv_capture_v3($0, $1, $2, $3, $4) },
 			NDIlib_recv_free_video_v2: { lib.NDIlib_recv_free_video_v2($0, $1) },
 			NDIlib_recv_free_audio_v3: { lib.NDIlib_recv_free_audio_v3($0, $1) },
-			NDIlib_recv_free_metadata: { lib.NDIlib_recv_free_metadata($0, $1) }
+			NDIlib_recv_free_metadata: { lib.NDIlib_recv_free_metadata($0, $1) },
+
+			NDIlib_send_create: { lib.NDIlib_send_create($0) },
+			NDIlib_send_destroy: { lib.NDIlib_send_destroy($0) },
+			NDIlib_send_send_video_v2: { lib.NDIlib_send_send_video_v2($0, $1) },
+			NDIlib_send_get_no_connections: { lib.NDIlib_send_get_no_connections($0, $1) },
+			NDIlib_send_get_source_name: { lib.NDIlib_send_get_source_name($0) }
 		)
 	}
 

--- a/Sources/NDI/NDI.swift
+++ b/Sources/NDI/NDI.swift
@@ -1,5 +1,6 @@
 import Dependencies
 import DependenciesMacros
+import Foundation
 import libNDI
 import OSLog
 
@@ -219,15 +220,35 @@ public extension NDI {
 			self.init(lib, retaining: runtime)
 		}
 
-		static let libraryPaths = [
-			"@executable_path/../Frameworks/libndi.dylib",
-			"libndi.dylib",
-			"/usr/local/lib/libndi.dylib",
-		]
+		static func libraryPaths(environment: [String: String] = ProcessInfo.processInfo.environment) -> [String] {
+			var paths = [
+				// App-bundled NDI redistributable; preferred for signed or sandboxed applications.
+				"@executable_path/../Frameworks/libndi.dylib",
+			]
+
+			// Cross-platform NDI runtime-directory override (`NDI_RUNTIME_DIR_V6`).
+			if let runtimeDirectory = environment[NDILIB_REDIST_FOLDER], !runtimeDirectory.isEmpty {
+				paths.append(
+					URL(fileURLWithPath: runtimeDirectory, isDirectory: true)
+						.appendingPathComponent(NDILIB_LIBRARY_NAME)
+						.path
+				)
+			}
+
+			paths.append(contentsOf: [
+				// Default NDI SDK for Apple installation.
+				"/Library/NDI SDK for Apple/lib/macOS/libndi.dylib",
+				// NDI macOS runtime redistributable installation.
+				"/usr/local/lib/libndi.dylib",
+				// Final macOS dyld leaf-name search, including LC_RPATH and development environment overrides.
+				NDILIB_LIBRARY_NAME,
+			])
+			return paths
+		}
 
 		static let sharedResult: Result<NDI, NDILoadError> = {
 			var lastError = NDILoadError.dlopenFailed(nil)
-			for path in libraryPaths {
+			for path in libraryPaths() {
 				do {
 					return try .success(NDI(libraryPath: path))
 				} catch {

--- a/Sources/NDI/NDI.swift
+++ b/Sources/NDI/NDI.swift
@@ -54,8 +54,6 @@ public struct NDI: Sendable {
 
 	var NDIlib_send_send_video_v2: @Sendable (NDIlib_send_instance_t?, UnsafePointer<NDIlib_video_frame_v2_t>?) -> Void
 
-	var NDIlib_send_send_audio_v2: @Sendable (NDIlib_send_instance_t?, UnsafePointer<NDIlib_audio_frame_v2_t>?) -> Void
-
 	var NDIlib_send_send_audio_v3: @Sendable (NDIlib_send_instance_t?, UnsafePointer<NDIlib_audio_frame_v3_t>?) -> Void
 
 	var NDIlib_send_send_metadata: @Sendable (NDIlib_send_instance_t?, UnsafePointer<NDIlib_metadata_frame_t>?) -> Void
@@ -174,7 +172,6 @@ public extension NDI {
 			NDIlib_send_create: { lib.NDIlib_send_create($0) },
 			NDIlib_send_destroy: { lib.NDIlib_send_destroy($0) },
 			NDIlib_send_send_video_v2: { lib.NDIlib_send_send_video_v2($0, $1) },
-			NDIlib_send_send_audio_v2: { lib.NDIlib_send_send_audio_v2($0, $1) },
 			NDIlib_send_send_audio_v3: { lib.NDIlib_send_send_audio_v3($0, $1) },
 			NDIlib_send_send_metadata: { lib.NDIlib_send_send_metadata($0, $1) },
 			NDIlib_send_capture: { lib.NDIlib_send_capture($0, $1, $2) },

--- a/Sources/NDI/NDI.swift
+++ b/Sources/NDI/NDI.swift
@@ -54,7 +54,25 @@ public struct NDI: Sendable {
 
 	var NDIlib_send_send_video_v2: @Sendable (NDIlib_send_instance_t?, UnsafePointer<NDIlib_video_frame_v2_t>?) -> Void
 
+	var NDIlib_send_send_audio_v2: @Sendable (NDIlib_send_instance_t?, UnsafePointer<NDIlib_audio_frame_v2_t>?) -> Void
+
+	var NDIlib_send_send_audio_v3: @Sendable (NDIlib_send_instance_t?, UnsafePointer<NDIlib_audio_frame_v3_t>?) -> Void
+
+	var NDIlib_send_send_metadata: @Sendable (NDIlib_send_instance_t?, UnsafePointer<NDIlib_metadata_frame_t>?) -> Void
+
+	var NDIlib_send_capture: @Sendable (NDIlib_send_instance_t?, UnsafeMutablePointer<NDIlib_metadata_frame_t>?, UInt32) -> NDIlib_frame_type_e = { _, _, _ in NDIlib_frame_type_none }
+
+	var NDIlib_send_free_metadata: @Sendable (NDIlib_send_instance_t?, UnsafePointer<NDIlib_metadata_frame_t>?) -> Void
+
+	var NDIlib_send_get_tally: @Sendable (NDIlib_send_instance_t?, UnsafeMutablePointer<NDIlib_tally_t>?, UInt32) -> Bool = { _, _, _ in false }
+
 	var NDIlib_send_get_no_connections: @Sendable (NDIlib_send_instance_t?, UInt32) -> Int32 = { _, _ in 0 }
+
+	var NDIlib_send_clear_connection_metadata: @Sendable (NDIlib_send_instance_t?) -> Void
+
+	var NDIlib_send_add_connection_metadata: @Sendable (NDIlib_send_instance_t?, UnsafePointer<NDIlib_metadata_frame_t>?) -> Void
+
+	var NDIlib_send_set_failover: @Sendable (NDIlib_send_instance_t?, UnsafePointer<NDIlib_source_t>?) -> Void
 
 	var NDIlib_send_get_source_name: @Sendable (NDIlib_send_instance_t?) -> UnsafePointer<NDIlib_source_t>?
 }
@@ -156,7 +174,16 @@ public extension NDI {
 			NDIlib_send_create: { lib.NDIlib_send_create($0) },
 			NDIlib_send_destroy: { lib.NDIlib_send_destroy($0) },
 			NDIlib_send_send_video_v2: { lib.NDIlib_send_send_video_v2($0, $1) },
+			NDIlib_send_send_audio_v2: { lib.NDIlib_send_send_audio_v2($0, $1) },
+			NDIlib_send_send_audio_v3: { lib.NDIlib_send_send_audio_v3($0, $1) },
+			NDIlib_send_send_metadata: { lib.NDIlib_send_send_metadata($0, $1) },
+			NDIlib_send_capture: { lib.NDIlib_send_capture($0, $1, $2) },
+			NDIlib_send_free_metadata: { lib.NDIlib_send_free_metadata($0, $1) },
+			NDIlib_send_get_tally: { lib.NDIlib_send_get_tally($0, $1, $2) },
 			NDIlib_send_get_no_connections: { lib.NDIlib_send_get_no_connections($0, $1) },
+			NDIlib_send_clear_connection_metadata: { lib.NDIlib_send_clear_connection_metadata($0) },
+			NDIlib_send_add_connection_metadata: { lib.NDIlib_send_add_connection_metadata($0, $1) },
+			NDIlib_send_set_failover: { lib.NDIlib_send_set_failover($0, $1) },
 			NDIlib_send_get_source_name: { lib.NDIlib_send_get_source_name($0) }
 		)
 	}

--- a/Sources/NDI/NDIAudioFrame.swift
+++ b/Sources/NDI/NDIAudioFrame.swift
@@ -236,7 +236,6 @@ public final class NDIReceivedAudioFrame: NDIAudioFrame, @unchecked Sendable {
 
 extension NDIAudioFrame: CustomStringConvertible {
 	public var description: String {
-		let timecode = ref.timecode == NDIlib_send_timecode_synthesize ? "synthesize" : ref.timecode.formatted()
 		let timestamp = ref.timestamp == NDIlib_recv_timestamp_undefined ? "undefined" : ref.timestamp.formatted()
 
 		return "<NDIAudioFrame sample_rate: \(sampleRate), no_channels: \(numberOfChannels), no_samples: \(numberOfSamples), timecode: \(ref.timecode), channel_stride_in_bytes: \(ref.channel_stride_in_bytes), p_metadata: \(metadata ?? ""), timestamp: \(timestamp)>"

--- a/Sources/NDI/NDIPlayer.swift
+++ b/Sources/NDI/NDIPlayer.swift
@@ -127,56 +127,74 @@ private final class NDIFrameSubscriptionToken: @unchecked Sendable {
 }
 
 public actor NDIPlayer {
-	private static let playerPool: Mutex<[String: Weak<NDIPlayer>]> = .init([:])
+	private struct PoolKey: Hashable {
+		var sourceName: String
+		var configuration: NDIReceiverConfiguration
+	}
 
-	public static func player(for name: String) -> NDIPlayer {
-		playerPool.withLock { pool in
-			if let player = pool[name]?.value {
+	private static let playerPool: Mutex<[PoolKey: Weak<NDIPlayer>]> = .init([:])
+
+	public static func player(
+		for name: String,
+		configuration: NDIReceiverConfiguration = .init()
+	) -> NDIPlayer {
+		let key = PoolKey(sourceName: name, configuration: configuration)
+		return playerPool.withLock { pool in
+			if let player = pool[key]?.value {
 				return player
 			} else {
-				let player = NDIPlayer(name: name)
-				pool[name] = .init(value: player)
+				let player = NDIPlayer(name: name, configuration: configuration)
+				pool[key] = .init(value: player)
 				return player
 			}
 		}
 	}
 
 	public nonisolated let sourceName: String
+	public nonisolated let configuration: NDIReceiverConfiguration
 	private var source: NDISource?
 
-	private let makeCapture: @Sendable (NDISource?, String) async -> NDIFrameCapture?
+	private let makeCapture: @Sendable (NDISource?, String, NDIReceiverConfiguration) async -> NDIFrameCapture?
 	private let startReceiveLoop: NDIReceiveLoopStarter
 
-	public init(name: String) {
+	public init(name: String, configuration: NDIReceiverConfiguration = .init()) {
 		self.sourceName = name
+		self.configuration = configuration
 		self.makeCapture = Self.liveCapture
 		self.startReceiveLoop = .live
 	}
 
-	public init(source: NDISource) {
+	public init(source: NDISource, configuration: NDIReceiverConfiguration = .init()) {
 		self.sourceName = source.name
 		self.source = source
+		self.configuration = configuration
 		self.makeCapture = Self.liveCapture
 		self.startReceiveLoop = .live
 	}
 
 	init(
 		name: String,
+		configuration: NDIReceiverConfiguration = .init(),
 		capture: NDIFrameCapture,
 		startReceiveLoop: NDIReceiveLoopStarter
 	) {
 		self.sourceName = name
-		self.makeCapture = { _, _ in capture }
+		self.configuration = configuration
+		self.makeCapture = { _, _, _ in capture }
 		self.startReceiveLoop = startReceiveLoop
 	}
 
-	private static func liveCapture(source: NDISource?, sourceName: String) async -> NDIFrameCapture? {
+	private static func liveCapture(
+		source: NDISource?,
+		sourceName: String,
+		configuration: NDIReceiverConfiguration
+	) async -> NDIFrameCapture? {
 		let receiver: NDIReceiver
 		if let source {
-			guard let sourceReceiver = NDIReceiver(source: source) else { return nil }
+			guard let sourceReceiver = NDIReceiver(source: source, configuration: configuration) else { return nil }
 			receiver = sourceReceiver
 		} else {
-			guard let namedReceiver = NDIReceiver() else { return nil }
+			guard let namedReceiver = NDIReceiver(configuration: configuration) else { return nil }
 			await namedReceiver.connect(name: sourceName)
 			receiver = namedReceiver
 		}
@@ -195,9 +213,10 @@ public actor NDIPlayer {
 
 		let source = self.source
 		let sourceName = self.sourceName
+		let configuration = self.configuration
 		let makeCapture = self.makeCapture
 		let task = Task {
-			await makeCapture(source, sourceName)
+			await makeCapture(source, sourceName, configuration)
 		}
 		getCaptureTask = task
 		return await task.value

--- a/Sources/NDI/NDIReceiver.swift
+++ b/Sources/NDI/NDIReceiver.swift
@@ -4,23 +4,66 @@ import Dependencies
 import libNDI
 import OSLog
 
+public struct NDIReceiverConfiguration: Hashable, Sendable {
+	public enum Bandwidth: Hashable, Sendable {
+		case highest
+		case lowest
+		case audioOnly
+
+		fileprivate var ndiValue: NDIlib_recv_bandwidth_e {
+			switch self {
+			case .highest:
+				NDIlib_recv_bandwidth_highest
+			case .lowest:
+				NDIlib_recv_bandwidth_lowest
+			case .audioOnly:
+				NDIlib_recv_bandwidth_audio_only
+			}
+		}
+	}
+
+	public enum Media: CaseIterable, Hashable, Sendable {
+		case video
+		case audio
+		case metadata
+	}
+
+	public var bandwidth: Bandwidth
+	public var capturedMedia: Set<Media>
+
+	public init(
+		bandwidth: Bandwidth = .highest,
+		capturedMedia: Set<Media> = Set(Media.allCases)
+	) {
+		self.bandwidth = bandwidth
+		self.capturedMedia = capturedMedia
+	}
+}
+
+public typealias NDICaptureType = NDIReceiverConfiguration.Media
+
 public final class NDIReceiver: @unchecked Sendable {
 	private let logger = Logger(category: "NDIReceiver")
 
 	let ndi: NDI
+	public let configuration: NDIReceiverConfiguration
 
 	let pNDI_recv: NDIlib_recv_instance_t
 
-	public init?(source: NDISource? = nil) {
+	public init?(
+		source: NDISource? = nil,
+		configuration: NDIReceiverConfiguration = .init()
+	) {
 		@Dependency(\.ndi) var ndi
 		guard let ndi else { return nil }
 
 		self.ndi = ndi
+		self.configuration = configuration
 
 		var recv_desc = NDIlib_recv_create_v3_t(
 			source_to_connect_to: source?.ref ?? NDIlib_source_t(),
 			color_format: NDIlib_recv_color_format_UYVY_BGRA,
-			bandwidth: NDIlib_recv_bandwidth_highest,
+			bandwidth: configuration.bandwidth.ndiValue,
 			allow_video_fields: true,
 			p_ndi_recv_name: nil
 		)
@@ -45,7 +88,11 @@ public final class NDIReceiver: @unchecked Sendable {
 		ndi.NDIlib_recv_connect(pNDI_recv, &sourceRef)
 	}
 
-	public func capture(types: Set<NDICaptureType> = Set(NDICaptureType.allCases), timeout: Duration = .zero) -> NDIReceivedFrame {
+	public func capture(
+		types: Set<NDICaptureType>? = nil,
+		timeout: Duration = .zero
+	) -> NDIReceivedFrame {
+		let types = (types ?? configuration.capturedMedia).intersection(configuration.capturedMedia)
 		// The descriptors
 		var video_frame: NDIlib_video_frame_v2_t = .init(
 			xres: 0,
@@ -117,12 +164,6 @@ public final class NDIReceiver: @unchecked Sendable {
 			return .unknown
 		}
 	}
-}
-
-public enum NDICaptureType: CaseIterable, Sendable {
-	case video
-	case audio
-	case metadata
 }
 
 public enum NDIReceivedFrame: Sendable {

--- a/Sources/NDI/NDISendAudioFrame.swift
+++ b/Sources/NDI/NDISendAudioFrame.swift
@@ -1,0 +1,113 @@
+//
+//  NDISendAudioFrame.swift
+//  swift-ndi
+//
+//  Created by David Beck on 8/26/26.
+//
+
+import CoreMedia
+import CoreVideo
+import Dependencies
+import libNDI
+
+/// An error that prevents an audio frame from being represented by NDI.
+public enum NDISendAudioFrameError: Error, Equatable, Sendable {
+	/// The sample rate is not a positive 32-bit integer.
+	case invalidSampleRate
+	/// No channel samples were supplied.
+	case noChannels
+	/// The channels do not all contain the same number of samples.
+	case inconsistentSampleCounts
+	/// The number of channels cannot be represented by the NDI SDK.
+	case tooManyChannels
+	/// The number of samples per channel cannot be represented by the NDI SDK.
+	case tooManySamples
+}
+
+/// A frame of planar, 32-bit floating-point audio to send over NDI.
+///
+/// Samples are stored channel by channel. Each channel must contain the same
+/// number of samples, and the frame keeps the sample storage alive until a
+/// synchronous send completes.
+public struct NDISendAudioFrame: Sendable {
+	/// The number of samples per second, in hertz.
+	public let sampleRate: Int
+	/// The number of audio channels in the frame.
+	public let numberOfChannels: Int
+	/// The number of audio samples in each channel.
+	public let numberOfSamples: Int
+	/// The frame's timecode, expressed in 100-nanosecond intervals.
+	public let timecode: NDITimecode
+	/// Per-frame metadata as a null-terminated UTF-8 XML string, or `nil` when absent.
+	public let metadata: String?
+
+	private let samples: [Float]
+
+	/// Creates a planar floating-point audio frame.
+	///
+	/// - Parameters:
+	///   - planarSamples: One array per channel. Every channel must contain the
+	///     same number of samples.
+	///   - sampleRate: The sample rate in hertz.
+	///   - timecode: The frame timecode. The default uses the current system time.
+	///   - metadata: Optional per-frame metadata in UTF-8 XML format.
+	/// - Throws: ``NDISendAudioFrameError`` when the sample rate, channel count,
+	///   or per-channel sample counts cannot form a valid NDI audio frame.
+	public init(
+		planarSamples: [[Float]],
+		sampleRate: Int = 48000,
+		timecode: NDITimecode = .now,
+		metadata: String? = nil
+	) throws {
+		guard sampleRate > 0, Int32(exactly: sampleRate) != nil else {
+			throw NDISendAudioFrameError.invalidSampleRate
+		}
+		guard let firstChannel = planarSamples.first else {
+			throw NDISendAudioFrameError.noChannels
+		}
+		guard Int32(exactly: planarSamples.count) != nil else {
+			throw NDISendAudioFrameError.tooManyChannels
+		}
+		guard Int32(exactly: firstChannel.count) != nil else {
+			throw NDISendAudioFrameError.tooManySamples
+		}
+		guard planarSamples.allSatisfy({ $0.count == firstChannel.count }) else {
+			throw NDISendAudioFrameError.inconsistentSampleCounts
+		}
+
+		self.sampleRate = sampleRate
+		numberOfChannels = planarSamples.count
+		numberOfSamples = firstChannel.count
+		self.timecode = timecode
+		self.metadata = metadata
+		samples = planarSamples.flatMap { $0 }
+	}
+
+	func withNDIFrame<R>(_ operation: (UnsafePointer<NDIlib_audio_frame_v3_t>) -> R) -> R {
+		samples.withUnsafeBufferPointer { samples in
+			withMetadataCString { metadata in
+				var frame = NDIlib_audio_frame_v3_t(
+					sample_rate: Int32(sampleRate),
+					no_channels: Int32(numberOfChannels),
+					no_samples: Int32(numberOfSamples),
+					timecode: timecode.rawValue,
+					FourCC: NDIlib_FourCC_audio_type_FLTP,
+					p_data: samples.baseAddress.map {
+						UnsafeMutableRawPointer(mutating: $0).assumingMemoryBound(to: UInt8.self)
+					},
+					.init(channel_stride_in_bytes: Int32(numberOfSamples * MemoryLayout<Float>.stride)),
+					p_metadata: metadata,
+					timestamp: 0
+				)
+				return withUnsafePointer(to: &frame, operation)
+			}
+		}
+	}
+
+	private func withMetadataCString<R>(_ operation: (UnsafePointer<CChar>?) -> R) -> R {
+		if let metadata {
+			return metadata.withCString(operation)
+		}
+		return operation(nil)
+	}
+}

--- a/Sources/NDI/NDISendMetadataFrame.swift
+++ b/Sources/NDI/NDISendMetadataFrame.swift
@@ -1,0 +1,40 @@
+//
+//  NDISendMetadataFrame.swift
+//  swift-ndi
+//
+//  Created by David Beck on 8/26/26.
+//
+
+import CoreMedia
+import CoreVideo
+import Dependencies
+import libNDI
+
+/// A UTF-8 XML metadata frame to send over NDI.
+public struct NDISendMetadataFrame: Hashable, Sendable {
+	/// The metadata payload in XML format.
+	public var value: String
+	/// The frame's timecode, expressed in 100-nanosecond intervals.
+	public var timecode: NDITimecode
+
+	/// Creates a metadata frame.
+	///
+	/// - Parameters:
+	///   - value: The metadata payload in XML format.
+	///   - timecode: The frame timecode. The default uses the current system time.
+	public init(value: String, timecode: NDITimecode = .now) {
+		self.value = value
+		self.timecode = timecode
+	}
+
+	func withNDIFrame<R>(_ operation: (UnsafePointer<NDIlib_metadata_frame_t>) -> R) -> R {
+		value.utf8CString.withUnsafeBufferPointer { value in
+			var frame = NDIlib_metadata_frame_t(
+				length: Int32(value.count),
+				timecode: timecode.rawValue,
+				p_data: value.baseAddress.map(UnsafeMutablePointer.init(mutating:))
+			)
+			return withUnsafePointer(to: &frame, operation)
+		}
+	}
+}

--- a/Sources/NDI/NDISendVideoFrame.swift
+++ b/Sources/NDI/NDISendVideoFrame.swift
@@ -1,0 +1,113 @@
+//
+//  NDISendVideoFrame.swift
+//  swift-ndi
+//
+//  Created by David Beck on 8/26/26.
+//
+
+import CoreMedia
+import CoreVideo
+import Dependencies
+import libNDI
+
+/// An error that prevents a pixel buffer from being represented by NDI.
+public enum NDISendVideoFrameError: Error, Equatable, Sendable {
+	/// The pixel buffer uses a format other than BGRA or UYVY.
+	case unsupportedPixelFormat(OSType)
+	/// The frame rate is invalid, nonpositive, or cannot be represented by the NDI SDK.
+	case invalidFrameRate
+	/// Core Video could not lock the pixel buffer for reading.
+	case couldNotLockPixelBuffer(CVReturn)
+	/// The locked pixel buffer has no accessible base address.
+	case missingPixelBufferBaseAddress
+}
+
+/// A progressive video frame to send over NDI.
+///
+/// The frame supports BGRA (`kCVPixelFormatType_32BGRA`) and UYVY
+/// (`kCVPixelFormatType_422YpCbCr8`) pixel buffers. It uses the pixel buffer's
+/// dimensions and row stride, and keeps the buffer alive until a synchronous
+/// send completes.
+public struct NDISendVideoFrame: @unchecked Sendable {
+	private let pixelBuffer: CVPixelBuffer
+	private let fourCC: NDIlib_FourCC_video_type_e
+	private let frameRateNumerator: Int32
+	private let frameRateDenominator: Int32
+	private let timecode: NDITimecode
+
+	/// Creates a progressive NDI video frame backed by a Core Video pixel buffer.
+	///
+	/// Express fractional rates as a rational `CMTime`. For example,
+	/// `CMTime(value: 30_000, timescale: 1_001)` represents 29.97 fps.
+	///
+	/// - Parameters:
+	///   - pixelBuffer: A BGRA or UYVY pixel buffer containing the video data.
+	///   - frameRate: The frame-rate numerator and denominator, represented by
+	///     the time's `value` and `timescale`, respectively.
+	///   - timecode: The frame timecode. The default uses the current system time.
+	/// - Throws: ``NDISendVideoFrameError`` when the frame rate or pixel format
+	///   is unsupported.
+	public init(
+		pixelBuffer: CVPixelBuffer,
+		frameRate: CMTime,
+		timecode: NDITimecode = .now
+	) throws {
+		guard
+			frameRate.isValid,
+			frameRate.value > 0,
+			frameRate.timescale > 0,
+			let numerator = Int32(exactly: frameRate.value)
+		else {
+			throw NDISendVideoFrameError.invalidFrameRate
+		}
+
+		let pixelFormat = CVPixelBufferGetPixelFormatType(pixelBuffer)
+		switch pixelFormat {
+		case kCVPixelFormatType_32BGRA:
+			fourCC = NDIlib_FourCC_video_type_BGRA
+		case kCVPixelFormatType_422YpCbCr8:
+			fourCC = NDIlib_FourCC_video_type_UYVY
+		default:
+			throw NDISendVideoFrameError.unsupportedPixelFormat(pixelFormat)
+		}
+
+		self.pixelBuffer = pixelBuffer
+		frameRateNumerator = numerator
+		frameRateDenominator = frameRate.timescale
+		self.timecode = timecode
+	}
+
+	func withNDIFrame<R>(
+		_ operation: (UnsafePointer<NDIlib_video_frame_v2_t>) -> R
+	) throws -> R {
+		let lockResult = CVPixelBufferLockBaseAddress(pixelBuffer, .readOnly)
+		guard lockResult == kCVReturnSuccess else {
+			throw NDISendVideoFrameError.couldNotLockPixelBuffer(lockResult)
+		}
+		defer {
+			CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly)
+		}
+
+		guard let baseAddress = CVPixelBufferGetBaseAddress(pixelBuffer) else {
+			throw NDISendVideoFrameError.missingPixelBufferBaseAddress
+		}
+
+		var frame = NDIlib_video_frame_v2_t(
+			xres: Int32(CVPixelBufferGetWidth(pixelBuffer)),
+			yres: Int32(CVPixelBufferGetHeight(pixelBuffer)),
+			FourCC: fourCC,
+			frame_rate_N: frameRateNumerator,
+			frame_rate_D: frameRateDenominator,
+			picture_aspect_ratio: Float(CVPixelBufferGetWidth(pixelBuffer)) / Float(CVPixelBufferGetHeight(pixelBuffer)),
+			frame_format_type: NDIlib_frame_format_type_progressive,
+			timecode: timecode.rawValue,
+			p_data: baseAddress.assumingMemoryBound(to: UInt8.self),
+			NDIlib_video_frame_v2_t.__Unnamed_union___Anonymous_field9(
+				line_stride_in_bytes: Int32(CVPixelBufferGetBytesPerRow(pixelBuffer))
+			),
+			p_metadata: nil,
+			timestamp: 0
+		)
+		return withUnsafePointer(to: &frame, operation)
+	}
+}

--- a/Sources/NDI/NDISender.swift
+++ b/Sources/NDI/NDISender.swift
@@ -83,6 +83,172 @@ public struct NDISendVideoFrame: @unchecked Sendable {
 	}
 }
 
+public enum NDISendAudioFrameError: Error, Equatable, Sendable {
+	case invalidSampleRate
+	case noChannels
+	case inconsistentSampleCounts
+	case tooManyChannels
+	case tooManySamples
+}
+
+/// Planar, 32-bit floating-point audio that remains alive until a synchronous NDI send completes.
+public struct NDISendAudioFrame: Sendable {
+	public enum Version: Equatable, Sendable {
+		case v2
+		case v3
+	}
+
+	public let sampleRate: Int
+	public let numberOfChannels: Int
+	public let numberOfSamples: Int
+	public let timecode: NDITimecode
+	public let metadata: String?
+
+	private let samples: [Float]
+
+	public init(
+		planarSamples: [[Float]],
+		sampleRate: Int = 48000,
+		timecode: NDITimecode = .now,
+		metadata: String? = nil
+	) throws {
+		guard sampleRate > 0, Int32(exactly: sampleRate) != nil else {
+			throw NDISendAudioFrameError.invalidSampleRate
+		}
+		guard let firstChannel = planarSamples.first else {
+			throw NDISendAudioFrameError.noChannels
+		}
+		guard Int32(exactly: planarSamples.count) != nil else {
+			throw NDISendAudioFrameError.tooManyChannels
+		}
+		guard Int32(exactly: firstChannel.count) != nil else {
+			throw NDISendAudioFrameError.tooManySamples
+		}
+		guard planarSamples.allSatisfy({ $0.count == firstChannel.count }) else {
+			throw NDISendAudioFrameError.inconsistentSampleCounts
+		}
+
+		self.sampleRate = sampleRate
+		numberOfChannels = planarSamples.count
+		numberOfSamples = firstChannel.count
+		self.timecode = timecode
+		self.metadata = metadata
+		samples = planarSamples.flatMap { $0 }
+	}
+
+	fileprivate func withNDIV2Frame<R>(_ operation: (UnsafePointer<NDIlib_audio_frame_v2_t>) -> R) -> R {
+		samples.withUnsafeBufferPointer { samples in
+			withMetadataCString { metadata in
+				var frame = NDIlib_audio_frame_v2_t(
+					sample_rate: Int32(sampleRate),
+					no_channels: Int32(numberOfChannels),
+					no_samples: Int32(numberOfSamples),
+					timecode: timecode.rawValue,
+					p_data: samples.baseAddress.map(UnsafeMutablePointer.init(mutating:)),
+					channel_stride_in_bytes: Int32(numberOfSamples * MemoryLayout<Float>.stride),
+					p_metadata: metadata,
+					timestamp: 0
+				)
+				return withUnsafePointer(to: &frame, operation)
+			}
+		}
+	}
+
+	fileprivate func withNDIV3Frame<R>(_ operation: (UnsafePointer<NDIlib_audio_frame_v3_t>) -> R) -> R {
+		samples.withUnsafeBufferPointer { samples in
+			withMetadataCString { metadata in
+				var frame = NDIlib_audio_frame_v3_t(
+					sample_rate: Int32(sampleRate),
+					no_channels: Int32(numberOfChannels),
+					no_samples: Int32(numberOfSamples),
+					timecode: timecode.rawValue,
+					FourCC: NDIlib_FourCC_audio_type_FLTP,
+					p_data: samples.baseAddress.map {
+						UnsafeMutableRawPointer(mutating: $0).assumingMemoryBound(to: UInt8.self)
+					},
+					.init(channel_stride_in_bytes: Int32(numberOfSamples * MemoryLayout<Float>.stride)),
+					p_metadata: metadata,
+					timestamp: 0
+				)
+				return withUnsafePointer(to: &frame, operation)
+			}
+		}
+	}
+
+	private func withMetadataCString<R>(_ operation: (UnsafePointer<CChar>?) -> R) -> R {
+		if let metadata {
+			return metadata.withCString(operation)
+		}
+		return operation(nil)
+	}
+}
+
+public struct NDISendMetadataFrame: Hashable, Sendable {
+	public var value: String
+	public var timecode: NDITimecode
+
+	public init(value: String, timecode: NDITimecode = .now) {
+		self.value = value
+		self.timecode = timecode
+	}
+
+	fileprivate func withNDIFrame<R>(_ operation: (UnsafePointer<NDIlib_metadata_frame_t>) -> R) -> R {
+		value.utf8CString.withUnsafeBufferPointer { value in
+			var frame = NDIlib_metadata_frame_t(
+				length: Int32(value.count),
+				timecode: timecode.rawValue,
+				p_data: value.baseAddress.map(UnsafeMutablePointer.init(mutating:))
+			)
+			return withUnsafePointer(to: &frame, operation)
+		}
+	}
+}
+
+public struct NDISenderTally: Equatable, Sendable {
+	public var isOnProgram: Bool
+	public var isOnPreview: Bool
+
+	public init(isOnProgram: Bool, isOnPreview: Bool) {
+		self.isOnProgram = isOnProgram
+		self.isOnPreview = isOnPreview
+	}
+}
+
+public enum NDISenderCaptureResult: Sendable {
+	case none
+	case metadata(NDISenderCapturedMetadataFrame)
+	case statusChange
+	case error
+	case unknown
+}
+
+public final class NDISenderCapturedMetadataFrame: @unchecked Sendable {
+	private var ref: NDIlib_metadata_frame_t
+	private let sender: NDISender
+
+	fileprivate init(ref: NDIlib_metadata_frame_t, sender: NDISender) {
+		self.ref = ref
+		self.sender = sender
+	}
+
+	deinit {
+		sender.freeMetadata(&ref)
+	}
+
+	public var timecode: NDITimecode {
+		NDITimecode(rawValue: ref.timecode)
+	}
+
+	public var value: String? {
+		guard let data = ref.p_data else { return nil }
+		if ref.length == 0 {
+			return String(cString: data)
+		}
+		let length = max(0, Int(ref.length) - 1)
+		return String(bytes: Data(bytes: data, count: length), encoding: .utf8)
+	}
+}
+
 public final class NDISender: @unchecked Sendable {
 	// NDIlib_send_instance_t is generally thread safe as long as it's not freed before NDIlib_send_send_video_v2_async finishes  (https://docs.ndi.video/all/developing-with-ndi/sdk/ndi-send).
 
@@ -93,10 +259,13 @@ public final class NDISender: @unchecked Sendable {
 	///
 	/// Returns `nil` when the NDI runtime cannot be loaded or the SDK cannot create
 	/// a sender with the supplied name.
-	public init?(name: String) {
+	public convenience init?(name: String) {
 		@Dependency(\.ndi) var ndi
 		guard let ndi else { return nil }
-		
+		self.init(name: name, ndi: ndi)
+	}
+
+	init?(name: String, ndi: NDI) {
 		self.ndi = ndi
 
 		let sender = name.withCString { name in
@@ -119,7 +288,7 @@ public final class NDISender: @unchecked Sendable {
 	public func connectionCount(timeout: Duration = .zero) -> Int {
 		Int(ndi.NDIlib_send_get_no_connections(
 			sender,
-			UInt32(timeout.seconds * 1_000)
+			UInt32(timeout.seconds * 1000)
 		))
 	}
 
@@ -131,15 +300,81 @@ public final class NDISender: @unchecked Sendable {
 		return String(cString: source.pointee.p_ndi_name)
 	}
 
-	/// This will add a video frame.
+	/// Adds a video frame synchronously.
 	public func send(_ frame: NDISendVideoFrame) throws {
-		do {
-			try frame.withNDIFrame { frame in
-				self.ndi.NDIlib_send_send_video_v2(self.sender, frame)
-			}
-		} catch {
-			throw error
+		try frame.withNDIFrame { frame in
+			ndi.NDIlib_send_send_video_v2(sender, frame)
 		}
+	}
+
+	/// Adds a planar floating-point audio frame synchronously.
+	public func send(_ frame: NDISendAudioFrame, version: NDISendAudioFrame.Version = .v3) {
+		switch version {
+		case .v2:
+			frame.withNDIV2Frame { ndi.NDIlib_send_send_audio_v2(sender, $0) }
+		case .v3:
+			frame.withNDIV3Frame { ndi.NDIlib_send_send_audio_v3(sender, $0) }
+		}
+	}
+
+	/// Sends metadata to all connected receivers.
+	public func send(_ frame: NDISendMetadataFrame) {
+		frame.withNDIFrame { ndi.NDIlib_send_send_metadata(sender, $0) }
+	}
+
+	/// Receives metadata sent back by a connected receiver.
+	public func capture(timeout: Duration = .zero) -> NDISenderCaptureResult {
+		var metadata = NDIlib_metadata_frame_t(length: 0, timecode: 0, p_data: nil)
+		let frameType = ndi.NDIlib_send_capture(
+			sender,
+			&metadata,
+			UInt32(timeout.seconds * 1000)
+		)
+
+		switch frameType {
+		case NDIlib_frame_type_none:
+			return .none
+		case NDIlib_frame_type_metadata:
+			return .metadata(NDISenderCapturedMetadataFrame(ref: metadata, sender: self))
+		case NDIlib_frame_type_status_change:
+			return .statusChange
+		case NDIlib_frame_type_error:
+			return .error
+		default:
+			return .unknown
+		}
+	}
+
+	/// Returns a tally update, or `nil` if the state did not change before the timeout.
+	public func tally(timeout: Duration = .zero) -> NDISenderTally? {
+		var tally = NDIlib_tally_t(on_program: false, on_preview: false)
+		guard ndi.NDIlib_send_get_tally(sender, &tally, UInt32(timeout.seconds * 1000)) else {
+			return nil
+		}
+		return NDISenderTally(isOnProgram: tally.on_program, isOnPreview: tally.on_preview)
+	}
+
+	/// Clears all metadata automatically sent to newly connected receivers.
+	public func clearConnectionMetadata() {
+		ndi.NDIlib_send_clear_connection_metadata(sender)
+	}
+
+	/// Adds metadata that is sent to existing and future receiver connections.
+	public func addConnectionMetadata(_ frame: NDISendMetadataFrame) {
+		frame.withNDIFrame { ndi.NDIlib_send_add_connection_metadata(sender, $0) }
+	}
+
+	/// Sets the source receivers should use if this sender becomes unavailable.
+	public func setFailoverSource(_ source: NDISource?) {
+		guard var source = source?.ref else {
+			ndi.NDIlib_send_set_failover(sender, nil)
+			return
+		}
+		ndi.NDIlib_send_set_failover(sender, &source)
+	}
+
+	fileprivate func freeMetadata(_ metadata: UnsafePointer<NDIlib_metadata_frame_t>) {
+		ndi.NDIlib_send_free_metadata(sender, metadata)
 	}
 }
 

--- a/Sources/NDI/NDISender.swift
+++ b/Sources/NDI/NDISender.swift
@@ -1,0 +1,155 @@
+import CoreMedia
+import CoreVideo
+import Dependencies
+import libNDI
+
+public enum NDISendVideoFrameError: Error, Equatable, Sendable {
+	case unsupportedPixelFormat(OSType)
+	case invalidFrameRate
+	case couldNotLockPixelBuffer(CVReturn)
+	case missingPixelBufferBaseAddress
+}
+
+/// A video frame that keeps its pixel buffer alive until the synchronous NDI send completes.
+public struct NDISendVideoFrame: @unchecked Sendable {
+	private let pixelBuffer: CVPixelBuffer
+	private let fourCC: NDIlib_FourCC_video_type_e
+	private let frameRateNumerator: Int32
+	private let frameRateDenominator: Int32
+	private let timecode: NDITimecode
+
+	public init(
+		pixelBuffer: CVPixelBuffer,
+		frameRate: CMTime,
+		timecode: NDITimecode = .now
+	) throws {
+		guard
+			frameRate.isValid,
+			frameRate.value > 0,
+			frameRate.timescale > 0,
+			let numerator = Int32(exactly: frameRate.value)
+		else {
+			throw NDISendVideoFrameError.invalidFrameRate
+		}
+
+		let pixelFormat = CVPixelBufferGetPixelFormatType(pixelBuffer)
+		switch pixelFormat {
+		case kCVPixelFormatType_32BGRA:
+			fourCC = NDIlib_FourCC_video_type_BGRA
+		case kCVPixelFormatType_422YpCbCr8:
+			fourCC = NDIlib_FourCC_video_type_UYVY
+		default:
+			throw NDISendVideoFrameError.unsupportedPixelFormat(pixelFormat)
+		}
+
+		self.pixelBuffer = pixelBuffer
+		frameRateNumerator = numerator
+		frameRateDenominator = frameRate.timescale
+		self.timecode = timecode
+	}
+
+	fileprivate func withNDIFrame<R>(
+		_ operation: (UnsafePointer<NDIlib_video_frame_v2_t>) -> R
+	) throws -> R {
+		let lockResult = CVPixelBufferLockBaseAddress(pixelBuffer, .readOnly)
+		guard lockResult == kCVReturnSuccess else {
+			throw NDISendVideoFrameError.couldNotLockPixelBuffer(lockResult)
+		}
+		defer {
+			CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly)
+		}
+
+		guard let baseAddress = CVPixelBufferGetBaseAddress(pixelBuffer) else {
+			throw NDISendVideoFrameError.missingPixelBufferBaseAddress
+		}
+
+		var frame = NDIlib_video_frame_v2_t(
+			xres: Int32(CVPixelBufferGetWidth(pixelBuffer)),
+			yres: Int32(CVPixelBufferGetHeight(pixelBuffer)),
+			FourCC: fourCC,
+			frame_rate_N: frameRateNumerator,
+			frame_rate_D: frameRateDenominator,
+			picture_aspect_ratio: Float(CVPixelBufferGetWidth(pixelBuffer)) / Float(CVPixelBufferGetHeight(pixelBuffer)),
+			frame_format_type: NDIlib_frame_format_type_progressive,
+			timecode: timecode.rawValue,
+			p_data: baseAddress.assumingMemoryBound(to: UInt8.self),
+			NDIlib_video_frame_v2_t.__Unnamed_union___Anonymous_field9(
+				line_stride_in_bytes: Int32(CVPixelBufferGetBytesPerRow(pixelBuffer))
+			),
+			p_metadata: nil,
+			timestamp: 0
+		)
+		return withUnsafePointer(to: &frame, operation)
+	}
+}
+
+public final class NDISender: @unchecked Sendable {
+	// NDIlib_send_instance_t is generally thread safe as long as it's not freed before NDIlib_send_send_video_v2_async finishes  (https://docs.ndi.video/all/developing-with-ndi/sdk/ndi-send).
+
+	private let ndi: NDI
+	private let sender: NDIlib_send_instance_t
+
+	init?(name: String, ndi: NDI) {
+		self.ndi = ndi
+
+		let sender = name.withCString { name in
+			var descriptor = NDIlib_send_create_t(
+				p_ndi_name: name,
+				p_groups: nil,
+				clock_video: false,
+				clock_audio: false
+			)
+			return ndi.NDIlib_send_create(&descriptor)
+		}
+		guard let sender else { return nil }
+		self.sender = sender
+	}
+
+	deinit {
+		ndi.NDIlib_send_destroy(sender)
+	}
+
+	func connectionCount(timeout: Duration = .zero) -> Int {
+		Int(ndi.NDIlib_send_get_no_connections(
+			sender,
+			UInt32(timeout.seconds * 1_000)
+		))
+	}
+
+	func sourceName() -> String? {
+		guard let source = ndi.NDIlib_send_get_source_name(sender) else {
+			return nil
+		}
+
+		return String(cString: source.pointee.p_ndi_name)
+	}
+
+	/// This will add a video frame.
+	func send(_ frame: NDISendVideoFrame) throws {
+		do {
+			try frame.withNDIFrame { frame in
+				self.ndi.NDIlib_send_send_video_v2(self.sender, frame)
+			}
+		} catch {
+			throw error
+		}
+	}
+}
+
+private final class NDISenderConnectionSubscriptionToken: @unchecked Sendable {
+	let id = UUID()
+	private let lock = NSLock()
+	private var cancelled = false
+
+	func cancel() {
+		lock.lock()
+		cancelled = true
+		lock.unlock()
+	}
+
+	var isCancelled: Bool {
+		lock.lock()
+		defer { lock.unlock() }
+		return cancelled
+	}
+}

--- a/Sources/NDI/NDISender.swift
+++ b/Sources/NDI/NDISender.swift
@@ -93,11 +93,6 @@ public enum NDISendAudioFrameError: Error, Equatable, Sendable {
 
 /// Planar, 32-bit floating-point audio that remains alive until a synchronous NDI send completes.
 public struct NDISendAudioFrame: Sendable {
-	public enum Version: Equatable, Sendable {
-		case v2
-		case v3
-	}
-
 	public let sampleRate: Int
 	public let numberOfChannels: Int
 	public let numberOfSamples: Int
@@ -136,25 +131,7 @@ public struct NDISendAudioFrame: Sendable {
 		samples = planarSamples.flatMap { $0 }
 	}
 
-	fileprivate func withNDIV2Frame<R>(_ operation: (UnsafePointer<NDIlib_audio_frame_v2_t>) -> R) -> R {
-		samples.withUnsafeBufferPointer { samples in
-			withMetadataCString { metadata in
-				var frame = NDIlib_audio_frame_v2_t(
-					sample_rate: Int32(sampleRate),
-					no_channels: Int32(numberOfChannels),
-					no_samples: Int32(numberOfSamples),
-					timecode: timecode.rawValue,
-					p_data: samples.baseAddress.map(UnsafeMutablePointer.init(mutating:)),
-					channel_stride_in_bytes: Int32(numberOfSamples * MemoryLayout<Float>.stride),
-					p_metadata: metadata,
-					timestamp: 0
-				)
-				return withUnsafePointer(to: &frame, operation)
-			}
-		}
-	}
-
-	fileprivate func withNDIV3Frame<R>(_ operation: (UnsafePointer<NDIlib_audio_frame_v3_t>) -> R) -> R {
+	fileprivate func withNDIFrame<R>(_ operation: (UnsafePointer<NDIlib_audio_frame_v3_t>) -> R) -> R {
 		samples.withUnsafeBufferPointer { samples in
 			withMetadataCString { metadata in
 				var frame = NDIlib_audio_frame_v3_t(
@@ -308,13 +285,8 @@ public final class NDISender: @unchecked Sendable {
 	}
 
 	/// Adds a planar floating-point audio frame synchronously.
-	public func send(_ frame: NDISendAudioFrame, version: NDISendAudioFrame.Version = .v3) {
-		switch version {
-		case .v2:
-			frame.withNDIV2Frame { ndi.NDIlib_send_send_audio_v2(sender, $0) }
-		case .v3:
-			frame.withNDIV3Frame { ndi.NDIlib_send_send_audio_v3(sender, $0) }
-		}
+	public func send(_ frame: NDISendAudioFrame) {
+		frame.withNDIFrame { ndi.NDIlib_send_send_audio_v3(sender, $0) }
 	}
 
 	/// Sends metadata to all connected receivers.

--- a/Sources/NDI/NDISender.swift
+++ b/Sources/NDI/NDISender.swift
@@ -89,7 +89,14 @@ public final class NDISender: @unchecked Sendable {
 	private let ndi: NDI
 	private let sender: NDIlib_send_instance_t
 
-	init?(name: String, ndi: NDI) {
+	/// Creates a sender using the process-wide NDI runtime.
+	///
+	/// Returns `nil` when the NDI runtime cannot be loaded or the SDK cannot create
+	/// a sender with the supplied name.
+	public init?(name: String) {
+		@Dependency(\.ndi) var ndi
+		guard let ndi else { return nil }
+		
 		self.ndi = ndi
 
 		let sender = name.withCString { name in
@@ -109,14 +116,14 @@ public final class NDISender: @unchecked Sendable {
 		ndi.NDIlib_send_destroy(sender)
 	}
 
-	func connectionCount(timeout: Duration = .zero) -> Int {
+	public func connectionCount(timeout: Duration = .zero) -> Int {
 		Int(ndi.NDIlib_send_get_no_connections(
 			sender,
 			UInt32(timeout.seconds * 1_000)
 		))
 	}
 
-	func sourceName() -> String? {
+	public func sourceName() -> String? {
 		guard let source = ndi.NDIlib_send_get_source_name(sender) else {
 			return nil
 		}
@@ -125,7 +132,7 @@ public final class NDISender: @unchecked Sendable {
 	}
 
 	/// This will add a video frame.
-	func send(_ frame: NDISendVideoFrame) throws {
+	public func send(_ frame: NDISendVideoFrame) throws {
 		do {
 			try frame.withNDIFrame { frame in
 				self.ndi.NDIlib_send_send_video_v2(self.sender, frame)

--- a/Sources/NDI/NDISender.swift
+++ b/Sources/NDI/NDISender.swift
@@ -3,229 +3,11 @@ import CoreVideo
 import Dependencies
 import libNDI
 
-public enum NDISendVideoFrameError: Error, Equatable, Sendable {
-	case unsupportedPixelFormat(OSType)
-	case invalidFrameRate
-	case couldNotLockPixelBuffer(CVReturn)
-	case missingPixelBufferBaseAddress
-}
-
-/// A video frame that keeps its pixel buffer alive until the synchronous NDI send completes.
-public struct NDISendVideoFrame: @unchecked Sendable {
-	private let pixelBuffer: CVPixelBuffer
-	private let fourCC: NDIlib_FourCC_video_type_e
-	private let frameRateNumerator: Int32
-	private let frameRateDenominator: Int32
-	private let timecode: NDITimecode
-
-	public init(
-		pixelBuffer: CVPixelBuffer,
-		frameRate: CMTime,
-		timecode: NDITimecode = .now
-	) throws {
-		guard
-			frameRate.isValid,
-			frameRate.value > 0,
-			frameRate.timescale > 0,
-			let numerator = Int32(exactly: frameRate.value)
-		else {
-			throw NDISendVideoFrameError.invalidFrameRate
-		}
-
-		let pixelFormat = CVPixelBufferGetPixelFormatType(pixelBuffer)
-		switch pixelFormat {
-		case kCVPixelFormatType_32BGRA:
-			fourCC = NDIlib_FourCC_video_type_BGRA
-		case kCVPixelFormatType_422YpCbCr8:
-			fourCC = NDIlib_FourCC_video_type_UYVY
-		default:
-			throw NDISendVideoFrameError.unsupportedPixelFormat(pixelFormat)
-		}
-
-		self.pixelBuffer = pixelBuffer
-		frameRateNumerator = numerator
-		frameRateDenominator = frameRate.timescale
-		self.timecode = timecode
-	}
-
-	fileprivate func withNDIFrame<R>(
-		_ operation: (UnsafePointer<NDIlib_video_frame_v2_t>) -> R
-	) throws -> R {
-		let lockResult = CVPixelBufferLockBaseAddress(pixelBuffer, .readOnly)
-		guard lockResult == kCVReturnSuccess else {
-			throw NDISendVideoFrameError.couldNotLockPixelBuffer(lockResult)
-		}
-		defer {
-			CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly)
-		}
-
-		guard let baseAddress = CVPixelBufferGetBaseAddress(pixelBuffer) else {
-			throw NDISendVideoFrameError.missingPixelBufferBaseAddress
-		}
-
-		var frame = NDIlib_video_frame_v2_t(
-			xres: Int32(CVPixelBufferGetWidth(pixelBuffer)),
-			yres: Int32(CVPixelBufferGetHeight(pixelBuffer)),
-			FourCC: fourCC,
-			frame_rate_N: frameRateNumerator,
-			frame_rate_D: frameRateDenominator,
-			picture_aspect_ratio: Float(CVPixelBufferGetWidth(pixelBuffer)) / Float(CVPixelBufferGetHeight(pixelBuffer)),
-			frame_format_type: NDIlib_frame_format_type_progressive,
-			timecode: timecode.rawValue,
-			p_data: baseAddress.assumingMemoryBound(to: UInt8.self),
-			NDIlib_video_frame_v2_t.__Unnamed_union___Anonymous_field9(
-				line_stride_in_bytes: Int32(CVPixelBufferGetBytesPerRow(pixelBuffer))
-			),
-			p_metadata: nil,
-			timestamp: 0
-		)
-		return withUnsafePointer(to: &frame, operation)
-	}
-}
-
-public enum NDISendAudioFrameError: Error, Equatable, Sendable {
-	case invalidSampleRate
-	case noChannels
-	case inconsistentSampleCounts
-	case tooManyChannels
-	case tooManySamples
-}
-
-/// Planar, 32-bit floating-point audio that remains alive until a synchronous NDI send completes.
-public struct NDISendAudioFrame: Sendable {
-	public let sampleRate: Int
-	public let numberOfChannels: Int
-	public let numberOfSamples: Int
-	public let timecode: NDITimecode
-	public let metadata: String?
-
-	private let samples: [Float]
-
-	public init(
-		planarSamples: [[Float]],
-		sampleRate: Int = 48000,
-		timecode: NDITimecode = .now,
-		metadata: String? = nil
-	) throws {
-		guard sampleRate > 0, Int32(exactly: sampleRate) != nil else {
-			throw NDISendAudioFrameError.invalidSampleRate
-		}
-		guard let firstChannel = planarSamples.first else {
-			throw NDISendAudioFrameError.noChannels
-		}
-		guard Int32(exactly: planarSamples.count) != nil else {
-			throw NDISendAudioFrameError.tooManyChannels
-		}
-		guard Int32(exactly: firstChannel.count) != nil else {
-			throw NDISendAudioFrameError.tooManySamples
-		}
-		guard planarSamples.allSatisfy({ $0.count == firstChannel.count }) else {
-			throw NDISendAudioFrameError.inconsistentSampleCounts
-		}
-
-		self.sampleRate = sampleRate
-		numberOfChannels = planarSamples.count
-		numberOfSamples = firstChannel.count
-		self.timecode = timecode
-		self.metadata = metadata
-		samples = planarSamples.flatMap { $0 }
-	}
-
-	fileprivate func withNDIFrame<R>(_ operation: (UnsafePointer<NDIlib_audio_frame_v3_t>) -> R) -> R {
-		samples.withUnsafeBufferPointer { samples in
-			withMetadataCString { metadata in
-				var frame = NDIlib_audio_frame_v3_t(
-					sample_rate: Int32(sampleRate),
-					no_channels: Int32(numberOfChannels),
-					no_samples: Int32(numberOfSamples),
-					timecode: timecode.rawValue,
-					FourCC: NDIlib_FourCC_audio_type_FLTP,
-					p_data: samples.baseAddress.map {
-						UnsafeMutableRawPointer(mutating: $0).assumingMemoryBound(to: UInt8.self)
-					},
-					.init(channel_stride_in_bytes: Int32(numberOfSamples * MemoryLayout<Float>.stride)),
-					p_metadata: metadata,
-					timestamp: 0
-				)
-				return withUnsafePointer(to: &frame, operation)
-			}
-		}
-	}
-
-	private func withMetadataCString<R>(_ operation: (UnsafePointer<CChar>?) -> R) -> R {
-		if let metadata {
-			return metadata.withCString(operation)
-		}
-		return operation(nil)
-	}
-}
-
-public struct NDISendMetadataFrame: Hashable, Sendable {
-	public var value: String
-	public var timecode: NDITimecode
-
-	public init(value: String, timecode: NDITimecode = .now) {
-		self.value = value
-		self.timecode = timecode
-	}
-
-	fileprivate func withNDIFrame<R>(_ operation: (UnsafePointer<NDIlib_metadata_frame_t>) -> R) -> R {
-		value.utf8CString.withUnsafeBufferPointer { value in
-			var frame = NDIlib_metadata_frame_t(
-				length: Int32(value.count),
-				timecode: timecode.rawValue,
-				p_data: value.baseAddress.map(UnsafeMutablePointer.init(mutating:))
-			)
-			return withUnsafePointer(to: &frame, operation)
-		}
-	}
-}
-
-public struct NDISenderTally: Equatable, Sendable {
-	public var isOnProgram: Bool
-	public var isOnPreview: Bool
-
-	public init(isOnProgram: Bool, isOnPreview: Bool) {
-		self.isOnProgram = isOnProgram
-		self.isOnPreview = isOnPreview
-	}
-}
-
-public enum NDISenderCaptureResult: Sendable {
-	case none
-	case metadata(NDISenderCapturedMetadataFrame)
-	case statusChange
-	case error
-	case unknown
-}
-
-public final class NDISenderCapturedMetadataFrame: @unchecked Sendable {
-	private var ref: NDIlib_metadata_frame_t
-	private let sender: NDISender
-
-	fileprivate init(ref: NDIlib_metadata_frame_t, sender: NDISender) {
-		self.ref = ref
-		self.sender = sender
-	}
-
-	deinit {
-		sender.freeMetadata(&ref)
-	}
-
-	public var timecode: NDITimecode {
-		NDITimecode(rawValue: ref.timecode)
-	}
-
-	public var value: String? {
-		guard let data = ref.p_data else { return nil }
-		if ref.length == 0 {
-			return String(cString: data)
-		}
-		let length = max(0, Int(ref.length) - 1)
-		return String(bytes: Data(bytes: data, count: length), encoding: .utf8)
-	}
-}
-
+/// An NDI source that sends video, audio, and metadata to receivers on the network.
+///
+/// The sender does not clock audio or video submissions. Pace calls to `send(_:)`
+/// at the rate represented by each frame. The sender remains advertised until it
+/// is deallocated.
 public final class NDISender: @unchecked Sendable {
 	// NDIlib_send_instance_t is generally thread safe as long as it's not freed before NDIlib_send_send_video_v2_async finishes  (https://docs.ndi.video/all/developing-with-ndi/sdk/ndi-send).
 
@@ -234,8 +16,9 @@ public final class NDISender: @unchecked Sendable {
 
 	/// Creates a sender using the process-wide NDI runtime.
 	///
-	/// Returns `nil` when the NDI runtime cannot be loaded or the SDK cannot create
-	/// a sender with the supplied name.
+	/// - Parameter name: The user-visible source name advertised on the NDI network.
+	/// - Returns: A sender, or `nil` when the NDI runtime cannot be loaded or the
+	///   SDK cannot create a sender with the supplied name.
 	public convenience init?(name: String) {
 		@Dependency(\.ndi) var ndi
 		guard let ndi else { return nil }
@@ -262,6 +45,15 @@ public final class NDISender: @unchecked Sendable {
 		ndi.NDIlib_send_destroy(sender)
 	}
 
+	/// Returns the current number of receivers connected to this source.
+	///
+	/// Use the result to avoid rendering or generating media while there are no
+	/// receivers. When `timeout` is greater than zero and no receiver is connected,
+	/// the call waits up to that duration for a connection.
+	///
+	/// - Parameter timeout: How long to wait for a receiver connection. Pass zero
+	///   to poll without waiting.
+	/// - Returns: The number of connected receivers.
 	public func connectionCount(timeout: Duration = .zero) -> Int {
 		Int(ndi.NDIlib_send_get_no_connections(
 			sender,
@@ -269,6 +61,12 @@ public final class NDISender: @unchecked Sendable {
 		))
 	}
 
+	/// Returns the source name advertised by this sender.
+	///
+	/// NDI normally qualifies the configured name with the machine name when it
+	/// advertises the source.
+	///
+	/// - Returns: The advertised source name, or `nil` if the SDK does not provide one.
 	public func sourceName() -> String? {
 		guard let source = ndi.NDIlib_send_get_source_name(sender) else {
 			return nil
@@ -277,24 +75,38 @@ public final class NDISender: @unchecked Sendable {
 		return String(cString: source.pointee.p_ndi_name)
 	}
 
-	/// Adds a video frame synchronously.
+	/// Sends a video frame synchronously.
+	///
+	/// The call returns after NDI finishes accessing the frame's pixel buffer.
+	///
+	/// - Parameter frame: The video frame to send to connected receivers.
+	/// - Throws: ``NDISendVideoFrameError`` if the pixel buffer cannot be locked
+	///   or accessed for the send.
 	public func send(_ frame: NDISendVideoFrame) throws {
 		try frame.withNDIFrame { frame in
 			ndi.NDIlib_send_send_video_v2(sender, frame)
 		}
 	}
 
-	/// Adds a planar floating-point audio frame synchronously.
+	/// Sends a planar floating-point audio frame synchronously.
+	///
+	/// - Parameter frame: The audio frame to send to connected receivers.
 	public func send(_ frame: NDISendAudioFrame) {
 		frame.withNDIFrame { ndi.NDIlib_send_send_audio_v3(sender, $0) }
 	}
 
 	/// Sends metadata to all connected receivers.
+	///
+	/// - Parameter frame: A UTF-8 XML metadata frame.
 	public func send(_ frame: NDISendMetadataFrame) {
 		frame.withNDIFrame { ndi.NDIlib_send_send_metadata(sender, $0) }
 	}
 
-	/// Receives metadata sent back by a connected receiver.
+	/// Waits for a message sent upstream by a connected receiver.
+	///
+	/// - Parameter timeout: How long to wait for a message. Pass zero to poll
+	///   without waiting.
+	/// - Returns: The captured message or the reason no metadata was returned.
 	public func capture(timeout: Duration = .zero) -> NDISenderCaptureResult {
 		var metadata = NDIlib_metadata_frame_t(length: 0, timecode: 0, p_data: nil)
 		let frameType = ndi.NDIlib_send_capture(
@@ -317,7 +129,12 @@ public final class NDISender: @unchecked Sendable {
 		}
 	}
 
-	/// Returns a tally update, or `nil` if the state did not change before the timeout.
+	/// Waits for the program or preview tally state to change.
+	///
+	/// - Parameter timeout: How long to wait for a change. Pass zero to poll the
+	///   current tally state without waiting.
+	/// - Returns: The current tally after a change, or `nil` when no change occurs
+	///   before the timeout.
 	public func tally(timeout: Duration = .zero) -> NDISenderTally? {
 		var tally = NDIlib_tally_t(on_program: false, on_preview: false)
 		guard ndi.NDIlib_send_get_tally(sender, &tally, UInt32(timeout.seconds * 1000)) else {
@@ -326,17 +143,30 @@ public final class NDISender: @unchecked Sendable {
 		return NDISenderTally(isOnProgram: tally.on_program, isOnPreview: tally.on_preview)
 	}
 
-	/// Clears all metadata automatically sent to newly connected receivers.
+	/// Clears all connection metadata queued for receivers.
+	///
+	/// Connection metadata is sent automatically whenever a new receiver connects.
 	public func clearConnectionMetadata() {
 		ndi.NDIlib_send_clear_connection_metadata(sender)
 	}
 
-	/// Adds metadata that is sent to existing and future receiver connections.
+	/// Adds metadata to send automatically with receiver connections.
+	///
+	/// The metadata is queued for each new connection and is also sent immediately
+	/// to receivers that are already connected. Call ``clearConnectionMetadata()``
+	/// to reset the queue.
+	///
+	/// - Parameter frame: A UTF-8 XML metadata frame describing the connection.
 	public func addConnectionMetadata(_ frame: NDISendMetadataFrame) {
 		frame.withNDIFrame { ndi.NDIlib_send_add_connection_metadata(sender, $0) }
 	}
 
-	/// Sets the source receivers should use if this sender becomes unavailable.
+	/// Sets the source that receivers should use if this sender becomes unavailable.
+	///
+	/// Receivers can switch back automatically if this sender returns. Pass `nil`
+	/// to clear the failover source.
+	///
+	/// - Parameter source: The fallback NDI source, or `nil` to remove the fallback.
 	public func setFailoverSource(_ source: NDISource?) {
 		guard var source = source?.ref else {
 			ndi.NDIlib_send_set_failover(sender, nil)
@@ -345,25 +175,7 @@ public final class NDISender: @unchecked Sendable {
 		ndi.NDIlib_send_set_failover(sender, &source)
 	}
 
-	fileprivate func freeMetadata(_ metadata: UnsafePointer<NDIlib_metadata_frame_t>) {
+	func freeMetadata(_ metadata: UnsafePointer<NDIlib_metadata_frame_t>) {
 		ndi.NDIlib_send_free_metadata(sender, metadata)
-	}
-}
-
-private final class NDISenderConnectionSubscriptionToken: @unchecked Sendable {
-	let id = UUID()
-	private let lock = NSLock()
-	private var cancelled = false
-
-	func cancel() {
-		lock.lock()
-		cancelled = true
-		lock.unlock()
-	}
-
-	var isCancelled: Bool {
-		lock.lock()
-		defer { lock.unlock() }
-		return cancelled
 	}
 }

--- a/Sources/NDI/NDISenderCaptureResult.swift
+++ b/Sources/NDI/NDISenderCaptureResult.swift
@@ -1,0 +1,60 @@
+//
+//  NDISenderCaptureResult.swift
+//  SignalGenerator
+//
+//  Created by David Beck on 8/26/26.
+//
+
+import CoreMedia
+import CoreVideo
+import Dependencies
+import libNDI
+
+/// The result of polling a sender for messages from connected receivers.
+public enum NDISenderCaptureResult: Sendable {
+	/// No message arrived before the timeout expired.
+	case none
+	/// A receiver sent a metadata frame upstream.
+	case metadata(NDISenderCapturedMetadataFrame)
+	/// The sender's connection status changed.
+	case statusChange
+	/// The NDI SDK reported an error.
+	case error
+	/// The NDI SDK returned a frame type this package does not recognize.
+	case unknown
+}
+
+/// A metadata frame sent upstream by a connected NDI receiver.
+///
+/// The object owns the SDK buffer and releases it when the object is
+/// deallocated. Copy ``value`` or ``timecode`` if they need to outlive the
+/// captured frame.
+public final class NDISenderCapturedMetadataFrame: @unchecked Sendable {
+	private var ref: NDIlib_metadata_frame_t
+	private let sender: NDISender
+
+	init(ref: NDIlib_metadata_frame_t, sender: NDISender) {
+		self.ref = ref
+		self.sender = sender
+	}
+
+	deinit {
+		sender.freeMetadata(&ref)
+	}
+
+	/// The metadata frame's timecode, expressed in 100-nanosecond intervals.
+	public var timecode: NDITimecode {
+		NDITimecode(rawValue: ref.timecode)
+	}
+
+	/// The received UTF-8 XML payload, or `nil` when the frame has no data or is
+	/// not valid UTF-8.
+	public var value: String? {
+		guard let data = ref.p_data else { return nil }
+		if ref.length == 0 {
+			return String(cString: data)
+		}
+		let length = max(0, Int(ref.length) - 1)
+		return String(bytes: Data(bytes: data, count: length), encoding: .utf8)
+	}
+}

--- a/Sources/NDI/NDISenderTally.swift
+++ b/Sources/NDI/NDISenderTally.swift
@@ -1,0 +1,29 @@
+//
+//  NDISenderTally.swift
+//  swift-ndi
+//
+//  Created by David Beck on 8/26/26.
+//
+
+import CoreMedia
+import CoreVideo
+import Dependencies
+import libNDI
+
+/// The program and preview tally state reported by connected receivers.
+public struct NDISenderTally: Equatable, Sendable {
+	/// Whether the source is currently on a receiver's program output.
+	public var isOnProgram: Bool
+	/// Whether the source is currently on a receiver's preview output.
+	public var isOnPreview: Bool
+
+	/// Creates a tally state.
+	///
+	/// - Parameters:
+	///   - isOnProgram: Whether the source is on program output.
+	///   - isOnPreview: Whether the source is on preview output.
+	public init(isOnProgram: Bool, isOnPreview: Bool) {
+		self.isOnProgram = isOnProgram
+		self.isOnPreview = isOnPreview
+	}
+}

--- a/Tests/NDITests/NDILibraryRuntimeTests.swift
+++ b/Tests/NDITests/NDILibraryRuntimeTests.swift
@@ -5,10 +5,22 @@ import Testing
 struct NDILibraryRuntimeTests {
 	@Test
 	func searchesTheApplicationFrameworksDirectoryFirst() {
-		#expect(NDI.libraryPaths == [
+		#expect(NDI.libraryPaths(environment: [:]) == [
 			"@executable_path/../Frameworks/libndi.dylib",
-			"libndi.dylib",
+			"/Library/NDI SDK for Apple/lib/macOS/libndi.dylib",
 			"/usr/local/lib/libndi.dylib",
+			"libndi.dylib",
+		])
+	}
+
+	@Test
+	func honorsTheNDIRuntimeDirectoryEnvironmentVariable() {
+		#expect(NDI.libraryPaths(environment: ["NDI_RUNTIME_DIR_V6": "/opt/ndi/runtime"]) == [
+			"@executable_path/../Frameworks/libndi.dylib",
+			"/opt/ndi/runtime/libndi.dylib",
+			"/Library/NDI SDK for Apple/lib/macOS/libndi.dylib",
+			"/usr/local/lib/libndi.dylib",
+			"libndi.dylib",
 		])
 	}
 

--- a/Tests/NDITests/NDILibraryRuntimeTests.swift
+++ b/Tests/NDITests/NDILibraryRuntimeTests.swift
@@ -4,6 +4,15 @@ import Testing
 
 struct NDILibraryRuntimeTests {
 	@Test
+	func searchesTheApplicationFrameworksDirectoryFirst() {
+		#expect(NDI.libraryPaths == [
+			"@executable_path/../Frameworks/libndi.dylib",
+			"libndi.dylib",
+			"/usr/local/lib/libndi.dylib",
+		])
+	}
+
+	@Test
 	func initializesOnceAndDestroysBeforeClosing() throws {
 		let events = Mutex<[String]>([])
 		var runtime: NDILibraryRuntime? = try NDILibraryRuntime(

--- a/Tests/NDITests/NDIReceiverConfigurationTests.swift
+++ b/Tests/NDITests/NDIReceiverConfigurationTests.swift
@@ -1,0 +1,68 @@
+import Dependencies
+import libNDI
+import Synchronization
+import Testing
+@testable import NDI
+
+struct NDIReceiverConfigurationTests {
+	@Test
+	func appliesBandwidthAndLimitsTheDefaultCapturedMedia() throws {
+		let probe = ReceiverProbe()
+		var ndi = NDI()
+		ndi.NDIlib_recv_create_v3 = probe.create
+		ndi.NDIlib_recv_destroy = { _ in }
+		ndi.NDIlib_recv_capture_v3 = probe.capture
+
+		let receiver = try #require(withDependencies {
+			$0.ndi = ndi
+		} operation: {
+			NDIReceiver(configuration: .init(bandwidth: .audioOnly, capturedMedia: [.audio]))
+		})
+
+		#expect(receiver.configuration == .init(bandwidth: .audioOnly, capturedMedia: [.audio]))
+		#expect(probe.bandwidth == NDIlib_recv_bandwidth_audio_only)
+		_ = receiver.capture()
+		#expect(probe.capturedMedia == [.audio])
+	}
+}
+
+private final class ReceiverProbe: @unchecked Sendable {
+	private struct State: Sendable {
+		var bandwidth: NDIlib_recv_bandwidth_e?
+		var capturedMedia: Set<NDICaptureType> = []
+	}
+
+	private let state = Mutex(State())
+
+	var bandwidth: NDIlib_recv_bandwidth_e? {
+		state.withLock(\.bandwidth)
+	}
+
+	var capturedMedia: Set<NDICaptureType> {
+		state.withLock(\.capturedMedia)
+	}
+
+	var create: @Sendable (UnsafePointer<NDIlib_recv_create_v3_t>?) -> NDIlib_recv_instance_t? {
+		{ [self] descriptor in
+			self.state.withLock { $0.bandwidth = descriptor?.pointee.bandwidth }
+			return NDIlib_recv_instance_t(bitPattern: 1)
+		}
+	}
+
+	var capture: @Sendable (
+		NDIlib_recv_instance_t?,
+		UnsafeMutablePointer<NDIlib_video_frame_v2_t>?,
+		UnsafeMutablePointer<NDIlib_audio_frame_v3_t>?,
+		UnsafeMutablePointer<NDIlib_metadata_frame_t>?,
+		UInt32
+	) -> NDIlib_frame_type_e {
+		{ [self] _, video, audio, metadata, _ in
+			self.state.withLock { state in
+				if video != nil { state.capturedMedia.insert(.video) }
+				if audio != nil { state.capturedMedia.insert(.audio) }
+				if metadata != nil { state.capturedMedia.insert(.metadata) }
+			}
+			return NDIlib_frame_type_none
+		}
+	}
+}

--- a/Tests/NDITests/NDISenderTests.swift
+++ b/Tests/NDITests/NDISenderTests.swift
@@ -1,9 +1,9 @@
 import CoreMedia
 import CoreVideo
 import libNDI
-@testable import NDI
 import Synchronization
 import Testing
+@testable import NDI
 
 struct NDISenderTests {
 	@Test
@@ -37,6 +37,97 @@ struct NDISenderTests {
 		let sender = try #require(NDISender(name: "swift-ndi sender test", ndi: probe.ndi))
 
 		#expect(sender.connectionCount() == 3)
+	}
+
+	@Test(arguments: [NDISendAudioFrame.Version.v2, .v3])
+	func sendsPlanarAudio(version: NDISendAudioFrame.Version) throws {
+		let probe = SenderProbe()
+		let sender = try #require(NDISender(name: "swift-ndi sender test", ndi: probe.ndi))
+		let frame = try NDISendAudioFrame(
+			planarSamples: [[0, 0.25, 0.5], [1, 0.75, 0.5]],
+			sampleRate: 48000,
+			timecode: NDITimecode(rawValue: 42),
+			metadata: "<audio/>"
+		)
+
+		sender.send(frame, version: version)
+
+		let snapshot = try #require(version == .v2 ? probe.audioV2 : probe.audioV3)
+		#expect(snapshot.sampleRate == 48000)
+		#expect(snapshot.numberOfChannels == 2)
+		#expect(snapshot.numberOfSamples == 3)
+		#expect(snapshot.timecode == 42)
+		#expect(snapshot.metadata == "<audio/>")
+		#expect(snapshot.samples == [0, 0.25, 0.5, 1, 0.75, 0.5])
+	}
+
+	@Test
+	func sendsAndConfiguresConnectionMetadata() throws {
+		let probe = SenderProbe()
+		let sender = try #require(NDISender(name: "swift-ndi sender test", ndi: probe.ndi))
+		let frame = NDISendMetadataFrame(value: "<product name=\"swift-ndi\"/>", timecode: .init(rawValue: 84))
+
+		sender.send(frame)
+		sender.addConnectionMetadata(frame)
+		sender.clearConnectionMetadata()
+
+		#expect(probe.sentMetadata == ["<product name=\"swift-ndi\"/>"])
+		#expect(probe.sentMetadataTimecodes == [84])
+		#expect(probe.connectionMetadata == ["<product name=\"swift-ndi\"/>"])
+		#expect(probe.clearConnectionMetadataCount == 1)
+	}
+
+	@Test
+	func capturesAndFreesReceiverMetadata() async throws {
+		let probe = SenderProbe()
+		probe.metadataToCapture = "<ndi_answer value=\"ok\"/>"
+		let sender = try #require(NDISender(name: "swift-ndi sender test", ndi: probe.ndi))
+		var frame: NDISenderCapturedMetadataFrame?
+
+		if case let .metadata(capturedFrame) = sender.capture() {
+			frame = capturedFrame
+		} else {
+			Issue.record("Expected captured metadata")
+		}
+
+		#expect(frame?.value == "<ndi_answer value=\"ok\"/>")
+		frame = nil
+		await Task.megaYield()
+		#expect(probe.freeMetadataCount == 1)
+	}
+
+	@Test
+	func reportsTallyChanges() throws {
+		let probe = SenderProbe()
+		probe.tally = NDISenderTally(isOnProgram: true, isOnPreview: false)
+		probe.tallyDidChange = true
+		let sender = try #require(NDISender(name: "swift-ndi sender test", ndi: probe.ndi))
+
+		#expect(sender.tally() == NDISenderTally(isOnProgram: true, isOnPreview: false))
+
+		probe.tallyDidChange = false
+		#expect(sender.tally() == nil)
+	}
+
+	@Test
+	func setsAndClearsFailoverSource() throws {
+		let probe = SenderProbe()
+		let sender = try #require(NDISender(name: "swift-ndi sender test", ndi: probe.ndi))
+
+		sender.setFailoverSource(NDISource(name: "Backup", url: "ndi://backup"))
+		#expect(probe.failoverSource == NDISourceSnapshot(name: "Backup", url: "ndi://backup"))
+
+		sender.setFailoverSource(nil)
+		#expect(probe.failoverSource == nil)
+		#expect(probe.clearedFailover)
+	}
+
+	@Test
+	func reportsSDKSourceName() throws {
+		let probe = SenderProbe()
+		let sender = try #require(NDISender(name: "swift-ndi sender test", ndi: probe.ndi))
+
+		#expect(sender.sourceName() == "TEST-HOST (swift-ndi sender test)")
 	}
 
 	@Test
@@ -73,6 +164,20 @@ struct NDISenderTests {
 	}
 }
 
+private struct AudioSnapshot: Equatable, Sendable {
+	var sampleRate: Int32
+	var numberOfChannels: Int32
+	var numberOfSamples: Int32
+	var timecode: Int64
+	var metadata: String?
+	var samples: [Float]
+}
+
+private struct NDISourceSnapshot: Equatable, Sendable {
+	var name: String
+	var url: String
+}
+
 private final class SenderProbe: @unchecked Sendable {
 	private struct State: Sendable {
 		var createCount = 0
@@ -80,14 +185,64 @@ private final class SenderProbe: @unchecked Sendable {
 		var sendCount = 0
 		var connectionCount = 0
 		var receivedVideoBuffer = false
+		var audioV2: AudioSnapshot?
+		var audioV3: AudioSnapshot?
+		var sentMetadata: [String] = []
+		var sentMetadataTimecodes: [Int64] = []
+		var connectionMetadata: [String] = []
+		var clearConnectionMetadataCount = 0
+		var metadataToCapture: String?
+		var freeMetadataCount = 0
+		var tally = NDISenderTally(isOnProgram: false, isOnPreview: false)
+		var tallyDidChange = false
+		var failoverSource: NDISourceSnapshot?
+		var clearedFailover = false
 	}
 
 	private let state = Mutex(State())
+	private let sourceName = UnsafeMutablePointer<CChar>.allocate(from: "TEST-HOST (swift-ndi sender test)")
+	private let sourceURL = UnsafeMutablePointer<CChar>.allocate(from: "ndi://test-host/source")
+	private let source = UnsafeMutablePointer<NDIlib_source_t>.allocate(capacity: 1)
+
+	init() {
+		source.initialize(to: NDIlib_source_t(p_ndi_name: sourceName, .init(p_url_address: sourceURL)))
+	}
+
+	deinit {
+		source.deinitialize(count: 1)
+		source.deallocate()
+		sourceName.deallocate()
+		sourceURL.deallocate()
+	}
 
 	var createCount: Int { state.withLock(\.createCount) }
 	var destroyCount: Int { state.withLock(\.destroyCount) }
 	var sendCount: Int { state.withLock(\.sendCount) }
 	var receivedVideoBuffer: Bool { state.withLock(\.receivedVideoBuffer) }
+	var audioV2: AudioSnapshot? { state.withLock(\.audioV2) }
+	var audioV3: AudioSnapshot? { state.withLock(\.audioV3) }
+	var sentMetadata: [String] { state.withLock(\.sentMetadata) }
+	var sentMetadataTimecodes: [Int64] { state.withLock(\.sentMetadataTimecodes) }
+	var connectionMetadata: [String] { state.withLock(\.connectionMetadata) }
+	var clearConnectionMetadataCount: Int { state.withLock(\.clearConnectionMetadataCount) }
+	var freeMetadataCount: Int { state.withLock(\.freeMetadataCount) }
+	var failoverSource: NDISourceSnapshot? { state.withLock(\.failoverSource) }
+	var clearedFailover: Bool { state.withLock(\.clearedFailover) }
+
+	var metadataToCapture: String? {
+		get { state.withLock(\.metadataToCapture) }
+		set { state.withLock { $0.metadataToCapture = newValue } }
+	}
+
+	var tally: NDISenderTally {
+		get { state.withLock(\.tally) }
+		set { state.withLock { $0.tally = newValue } }
+	}
+
+	var tallyDidChange: Bool {
+		get { state.withLock(\.tallyDidChange) }
+		set { state.withLock { $0.tallyDidChange = newValue } }
+	}
 
 	var connectionCount: Int {
 		get { state.withLock(\.connectionCount) }
@@ -113,6 +268,107 @@ private final class SenderProbe: @unchecked Sendable {
 				state.receivedVideoBuffer = frame?.pointee.p_data != nil
 			}
 		}
+		ndi.NDIlib_send_send_audio_v2 = { [probe] _, frame in
+			guard let frame else { return }
+			probe.state.withLock { $0.audioV2 = Self.snapshot(frame.pointee) }
+		}
+		ndi.NDIlib_send_send_audio_v3 = { [probe] _, frame in
+			guard let frame else { return }
+			probe.state.withLock { $0.audioV3 = Self.snapshot(frame.pointee) }
+		}
+		ndi.NDIlib_send_send_metadata = { [probe] _, frame in
+			guard let frame else { return }
+			probe.state.withLock {
+				$0.sentMetadata.append(Self.metadataString(frame.pointee) ?? "")
+				$0.sentMetadataTimecodes.append(frame.pointee.timecode)
+			}
+		}
+		ndi.NDIlib_send_capture = { [probe] _, metadata, _ in
+			guard let value = probe.state.withLock(\.metadataToCapture), let metadata else {
+				return NDIlib_frame_type_none
+			}
+			let data = UnsafeMutablePointer<CChar>.allocate(from: value)
+			metadata.pointee = NDIlib_metadata_frame_t(
+				length: Int32(value.utf8.count + 1),
+				timecode: 123,
+				p_data: data
+			)
+			return NDIlib_frame_type_metadata
+		}
+		ndi.NDIlib_send_free_metadata = { [probe] _, metadata in
+			metadata?.pointee.p_data?.deallocate()
+			probe.state.withLock { $0.freeMetadataCount += 1 }
+		}
+		ndi.NDIlib_send_get_tally = { [probe] _, tally, _ in
+			let snapshot = probe.state.withLock { ($0.tally, $0.tallyDidChange) }
+			tally?.pointee = NDIlib_tally_t(
+				on_program: snapshot.0.isOnProgram,
+				on_preview: snapshot.0.isOnPreview
+			)
+			return snapshot.1
+		}
+		ndi.NDIlib_send_clear_connection_metadata = { [probe] _ in
+			probe.state.withLock { $0.clearConnectionMetadataCount += 1 }
+		}
+		ndi.NDIlib_send_add_connection_metadata = { [probe] _, frame in
+			guard let frame else { return }
+			probe.state.withLock { $0.connectionMetadata.append(Self.metadataString(frame.pointee) ?? "") }
+		}
+		ndi.NDIlib_send_set_failover = { [probe] _, source in
+			probe.state.withLock { state in
+				guard let source else {
+					state.failoverSource = nil
+					state.clearedFailover = true
+					return
+				}
+				state.failoverSource = NDISourceSnapshot(
+					name: String(cString: source.pointee.p_ndi_name),
+					url: String(cString: source.pointee.p_url_address)
+				)
+			}
+		}
+		ndi.NDIlib_send_get_source_name = { [probe] _ in UnsafePointer(probe.source) }
 		return ndi
+	}
+
+	private static func snapshot(_ frame: NDIlib_audio_frame_v2_t) -> AudioSnapshot {
+		let count = Int(frame.no_channels * frame.no_samples)
+		return AudioSnapshot(
+			sampleRate: frame.sample_rate,
+			numberOfChannels: frame.no_channels,
+			numberOfSamples: frame.no_samples,
+			timecode: frame.timecode,
+			metadata: frame.p_metadata.map(String.init(cString:)),
+			samples: frame.p_data.map { Array(UnsafeBufferPointer(start: $0, count: count)) } ?? []
+		)
+	}
+
+	private static func snapshot(_ frame: NDIlib_audio_frame_v3_t) -> AudioSnapshot {
+		let count = Int(frame.no_channels * frame.no_samples)
+		let samples = frame.p_data.map {
+			Array(UnsafeBufferPointer(start: UnsafeRawPointer($0).assumingMemoryBound(to: Float.self), count: count))
+		} ?? []
+		return AudioSnapshot(
+			sampleRate: frame.sample_rate,
+			numberOfChannels: frame.no_channels,
+			numberOfSamples: frame.no_samples,
+			timecode: frame.timecode,
+			metadata: frame.p_metadata.map(String.init(cString:)),
+			samples: samples
+		)
+	}
+
+	private static func metadataString(_ frame: NDIlib_metadata_frame_t) -> String? {
+		frame.p_data.map { String(cString: $0) }
+	}
+}
+
+private extension UnsafeMutablePointer<CChar> {
+	static func allocate(from string: String) -> Self {
+		string.utf8CString.withUnsafeBufferPointer { buffer in
+			let pointer = UnsafeMutablePointer<CChar>.allocate(capacity: buffer.count)
+			pointer.initialize(from: buffer.baseAddress!, count: buffer.count)
+			return pointer
+		}
 	}
 }

--- a/Tests/NDITests/NDISenderTests.swift
+++ b/Tests/NDITests/NDISenderTests.swift
@@ -20,6 +20,26 @@ struct NDISenderTests {
 	}
 
 	@Test
+	func sendsVideoFramesSynchronously() throws {
+		let probe = SenderProbe()
+		let sender = try #require(NDISender(name: "swift-ndi sender test", ndi: probe.ndi))
+
+		try sender.send(makeFrame())
+
+		#expect(probe.sendCount == 1)
+		#expect(probe.receivedVideoBuffer)
+	}
+
+	@Test
+	func reportsConnectedReceivers() throws {
+		let probe = SenderProbe()
+		probe.connectionCount = 3
+		let sender = try #require(NDISender(name: "swift-ndi sender test", ndi: probe.ndi))
+
+		#expect(sender.connectionCount() == 3)
+	}
+
+	@Test
 	func keepsPooledPlayersSeparateForEachReceiverConfiguration() {
 		let highest = NDIPlayer.player(for: "Configuration Test")
 		let lowest = NDIPlayer.player(

--- a/Tests/NDITests/NDISenderTests.swift
+++ b/Tests/NDITests/NDISenderTests.swift
@@ -1,0 +1,98 @@
+import CoreMedia
+import CoreVideo
+import libNDI
+@testable import NDI
+import Synchronization
+import Testing
+
+struct NDISenderTests {
+	@Test
+	func createsAndDestroysTheSDKSenderOnce() async throws {
+		let probe = SenderProbe()
+		var sender: NDISender? = NDISender(name: "swift-ndi sender test", ndi: probe.ndi)
+
+		#expect(sender != nil)
+		#expect(probe.createCount == 1)
+
+		sender = nil
+		await Task.megaYield()
+		#expect(probe.destroyCount == 1)
+	}
+
+	@Test
+	func keepsPooledPlayersSeparateForEachReceiverConfiguration() {
+		let highest = NDIPlayer.player(for: "Configuration Test")
+		let lowest = NDIPlayer.player(
+			for: "Configuration Test",
+			configuration: .init(bandwidth: .lowest, capturedMedia: [.video])
+		)
+		let lowestAgain = NDIPlayer.player(
+			for: "Configuration Test",
+			configuration: .init(bandwidth: .lowest, capturedMedia: [.video])
+		)
+
+		#expect(highest !== lowest)
+		#expect(lowest === lowestAgain)
+	}
+
+	private func makeFrame() throws -> NDISendVideoFrame {
+		var pixelBuffer: CVPixelBuffer?
+		#expect(CVPixelBufferCreate(
+			kCFAllocatorDefault,
+			2,
+			2,
+			kCVPixelFormatType_32BGRA,
+			[kCVPixelBufferIOSurfacePropertiesKey: [:]] as CFDictionary,
+			&pixelBuffer
+		) == kCVReturnSuccess)
+		return try NDISendVideoFrame(
+			pixelBuffer: #require(pixelBuffer),
+			frameRate: CMTime(value: 2, timescale: 1),
+			timecode: .init(rawValue: NDIlib_send_timecode_synthesize)
+		)
+	}
+}
+
+private final class SenderProbe: @unchecked Sendable {
+	private struct State: Sendable {
+		var createCount = 0
+		var destroyCount = 0
+		var sendCount = 0
+		var connectionCount = 0
+		var receivedVideoBuffer = false
+	}
+
+	private let state = Mutex(State())
+
+	var createCount: Int { state.withLock(\.createCount) }
+	var destroyCount: Int { state.withLock(\.destroyCount) }
+	var sendCount: Int { state.withLock(\.sendCount) }
+	var receivedVideoBuffer: Bool { state.withLock(\.receivedVideoBuffer) }
+
+	var connectionCount: Int {
+		get { state.withLock(\.connectionCount) }
+		set { state.withLock { $0.connectionCount = newValue } }
+	}
+
+	var ndi: NDI {
+		let probe = self
+		var ndi = NDI()
+		ndi.NDIlib_send_create = { [probe] _ in
+			probe.state.withLock { $0.createCount += 1 }
+			return NDIlib_send_instance_t(bitPattern: 1)
+		}
+		ndi.NDIlib_send_destroy = { [probe] _ in
+			probe.state.withLock { $0.destroyCount += 1 }
+		}
+		ndi.NDIlib_send_get_no_connections = { [probe] _, _ in
+			probe.state.withLock { Int32($0.connectionCount) }
+		}
+		ndi.NDIlib_send_send_video_v2 = { [probe] _, frame in
+			probe.state.withLock { state in
+				state.sendCount += 1
+				state.receivedVideoBuffer = frame?.pointee.p_data != nil
+			}
+		}
+		return ndi
+	}
+}

--- a/Tests/NDITests/NDISenderTests.swift
+++ b/Tests/NDITests/NDISenderTests.swift
@@ -39,8 +39,8 @@ struct NDISenderTests {
 		#expect(sender.connectionCount() == 3)
 	}
 
-	@Test(arguments: [NDISendAudioFrame.Version.v2, .v3])
-	func sendsPlanarAudio(version: NDISendAudioFrame.Version) throws {
+	@Test
+	func sendsPlanarAudio() throws {
 		let probe = SenderProbe()
 		let sender = try #require(NDISender(name: "swift-ndi sender test", ndi: probe.ndi))
 		let frame = try NDISendAudioFrame(
@@ -50,9 +50,9 @@ struct NDISenderTests {
 			metadata: "<audio/>"
 		)
 
-		sender.send(frame, version: version)
+		sender.send(frame)
 
-		let snapshot = try #require(version == .v2 ? probe.audioV2 : probe.audioV3)
+		let snapshot = try #require(probe.audio)
 		#expect(snapshot.sampleRate == 48000)
 		#expect(snapshot.numberOfChannels == 2)
 		#expect(snapshot.numberOfSamples == 3)
@@ -185,8 +185,7 @@ private final class SenderProbe: @unchecked Sendable {
 		var sendCount = 0
 		var connectionCount = 0
 		var receivedVideoBuffer = false
-		var audioV2: AudioSnapshot?
-		var audioV3: AudioSnapshot?
+		var audio: AudioSnapshot?
 		var sentMetadata: [String] = []
 		var sentMetadataTimecodes: [Int64] = []
 		var connectionMetadata: [String] = []
@@ -219,8 +218,7 @@ private final class SenderProbe: @unchecked Sendable {
 	var destroyCount: Int { state.withLock(\.destroyCount) }
 	var sendCount: Int { state.withLock(\.sendCount) }
 	var receivedVideoBuffer: Bool { state.withLock(\.receivedVideoBuffer) }
-	var audioV2: AudioSnapshot? { state.withLock(\.audioV2) }
-	var audioV3: AudioSnapshot? { state.withLock(\.audioV3) }
+	var audio: AudioSnapshot? { state.withLock(\.audio) }
 	var sentMetadata: [String] { state.withLock(\.sentMetadata) }
 	var sentMetadataTimecodes: [Int64] { state.withLock(\.sentMetadataTimecodes) }
 	var connectionMetadata: [String] { state.withLock(\.connectionMetadata) }
@@ -268,13 +266,9 @@ private final class SenderProbe: @unchecked Sendable {
 				state.receivedVideoBuffer = frame?.pointee.p_data != nil
 			}
 		}
-		ndi.NDIlib_send_send_audio_v2 = { [probe] _, frame in
-			guard let frame else { return }
-			probe.state.withLock { $0.audioV2 = Self.snapshot(frame.pointee) }
-		}
 		ndi.NDIlib_send_send_audio_v3 = { [probe] _, frame in
 			guard let frame else { return }
-			probe.state.withLock { $0.audioV3 = Self.snapshot(frame.pointee) }
+			probe.state.withLock { $0.audio = Self.snapshot(frame.pointee) }
 		}
 		ndi.NDIlib_send_send_metadata = { [probe] _, frame in
 			guard let frame else { return }
@@ -329,18 +323,6 @@ private final class SenderProbe: @unchecked Sendable {
 		}
 		ndi.NDIlib_send_get_source_name = { [probe] _ in UnsafePointer(probe.source) }
 		return ndi
-	}
-
-	private static func snapshot(_ frame: NDIlib_audio_frame_v2_t) -> AudioSnapshot {
-		let count = Int(frame.no_channels * frame.no_samples)
-		return AudioSnapshot(
-			sampleRate: frame.sample_rate,
-			numberOfChannels: frame.no_channels,
-			numberOfSamples: frame.no_samples,
-			timecode: frame.timecode,
-			metadata: frame.p_metadata.map(String.init(cString:)),
-			samples: frame.p_data.map { Array(UnsafeBufferPointer(start: $0, count: count)) } ?? []
-		)
 	}
 
 	private static func snapshot(_ frame: NDIlib_audio_frame_v3_t) -> AudioSnapshot {


### PR DESCRIPTION
## Summary
- add receiver bandwidth and captured-media configuration, including player-pool isolation
- add a queue-owned NDI sender with safe synchronous pixel-buffer submission and connection-count streams
- cover receiver configuration, sender lifetime, zero-receiver behavior, connection transitions, and cancellation

## Validation
- swift test (29 tests)
- swift build --triple arm64-apple-ios26.0
- live receiver matrix: Friday, Jarvis, and Mevo all delivered 640x360 lowest-bandwidth video and audio-only frames
- live local sender: discovery, 0 to 1 to 0 receiver transitions, and a received 320x180 frame