### PR TITLE
Replace Foundation.Process with swift-subprocess

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "adc3a3ca648d9327322acd3fe337d3f3bf9dd87b6fe8ae24c48e5c196839f55a",
+  "originHash" : "d0804e2d9fe5a67987253289ac357ee823ddf5cf8d4e3b1c5772ff1e348e0ac0",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -38,12 +38,30 @@
       }
     },
     {
+      "identity" : "swift-subprocess",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-subprocess.git",
+      "state" : {
+        "revision" : "b3937ab85dd32f6e9435914599c1519074769c1a",
+        "version" : "1.0.0"
+      }
+    },
+    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
         "revision" : "0687f71944021d616d34d922343dcef086855920",
         "version" : "600.0.1"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system",
+      "state" : {
+        "revision" : "869129b7bf4ecc57b97d0193ad29690ca2134750",
+        "version" : "1.8.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -19,6 +19,7 @@ let package = Package(
 	dependencies: [
 		.package(url: "https://github.com/pointfreeco/swift-dependencies.git", from: "1.7.0"),
 		.package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.4.0"),
+		.package(url: "https://github.com/swiftlang/swift-subprocess.git", from: "1.0.0"),
 	],
 	targets: [
 		.target(
@@ -28,6 +29,11 @@ let package = Package(
 				.product(name: "Dependencies", package: "swift-dependencies"),
 				.product(name: "DependenciesMacros", package: "swift-dependencies"),
 				.product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
+				.product(
+					name: "Subprocess",
+					package: "swift-subprocess",
+					condition: .when(platforms: [.macOS])
+				),
 			],
 			linkerSettings: [
 //				.unsafeFlags([

--- a/Sources/NDI/Recording/NDIRecorder.swift
+++ b/Sources/NDI/Recording/NDIRecorder.swift
@@ -2,6 +2,7 @@
 	import Foundation
 	import IssueReporting
 	import OSLog
+	import Subprocess
 
 	private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "", category: "NDIRecorder")
 
@@ -9,10 +10,7 @@
 	///
 	/// You will need to have access to the NDI recording executable at runtime. When the NDI SDK is installed, this is located at `/Library/NDI\ SDK\ for\ Apple/bin/Application.Mac.NDI.Recording`.
 	public final class NDIRecorder {
-		let process = Process()
-		let standardOutput = Pipe()
-		let standardError = Pipe()
-		let standardInput = Pipe()
+		private var commandContinuation: AsyncStream<Command>.Continuation?
 
 		public let inputName: String
 
@@ -36,14 +34,9 @@
 			writeThumbnail: Bool = true,
 			autostart: Bool = true,
 			autochop: Bool = true
-		) throws -> MessageStream {
+		) async throws -> MessageStream {
 			let inputName = self.inputName
-
-			process.standardOutput = standardOutput
-			process.standardError = standardError
-			process.standardInput = standardInput
-
-			process.executableURL = executableURL
+			let executablePath = executableURL.path(percentEncoded: false)
 
 //			/Library/NDI\ SDK\ for\ Apple/bin/Application.Mac.NDI.Recording -i "MEVO-N648P (MEVO-N648P)" -o Test/Library/NDI\ SDK\ for\ Apple/bin/Application.Mac.NDI.DirectoryService
 
@@ -75,69 +68,120 @@
 			if !autostart {
 				arguments.append("-noautostart")
 			}
+			let processArguments = arguments
 
-			process.arguments = arguments
 			logger.info("starting recording of '\(inputName)' at '\(outputPath)'")
 
-			try process.run()
+			let (messageStream, messageContinuation) = AsyncThrowingStream.makeStream(of: NDIMessage.self)
+			let (commands, commandContinuation) = AsyncStream.makeStream(of: Command.self)
+			self.commandContinuation = commandContinuation
 
-			Task { [standardError] in
-				for try await line in standardError.fileHandleForReading.bytes.lines {
-					logger.info("\(line)")
+			try await withCheckedThrowingContinuation { continuation in
+				let launchSignal = LaunchSignal(continuation: continuation)
+				Task {
+					do {
+						_ = try await run(
+							.path(.init(executablePath)),
+							arguments: .init(processArguments),
+							input: .inputWriter,
+							output: .sequence,
+							error: .sequence
+						) { execution in
+							await launchSignal.succeed()
+
+							try await withThrowingTaskGroup(of: Void.self) { group in
+								group.addTask {
+									defer { commandContinuation.finish() }
+									for try await line in execution.standardOutput.strings() {
+										do {
+											messageContinuation.yield(try NDIMessageParser.parse(line: line))
+										} catch {
+											logger.error("failed to decode message '\(line)': \(error)")
+										}
+									}
+								}
+								group.addTask {
+									for try await line in execution.standardError.strings() {
+										logger.info("\(line)")
+									}
+								}
+								group.addTask {
+									for await command in commands {
+										do {
+											_ = try await execution.standardInputWriter.write(command.value)
+											command.acknowledgement.resume()
+										} catch {
+											command.acknowledgement.resume(throwing: error)
+											throw error
+										}
+									}
+									try await execution.standardInputWriter.finish()
+								}
+								try await group.waitForAll()
+							}
+						}
+						messageContinuation.finish()
+					} catch {
+						await launchSignal.fail(with: error)
+						commandContinuation.finish()
+						messageContinuation.finish(throwing: error)
+					}
 				}
 			}
 
-			let stream = standardOutput.fileHandleForReading.bytes.lines
-				.compactMap { line in
-					do {
-						return try NDIMessageParser.parse(line: line)
-					} catch {
-						logger.error("failed to decode message '\(line)': \(error)")
-						return nil
-					}
-				}
-
-			return MessageStream(underlyingStream: stream)
+			return MessageStream(underlyingStream: messageStream)
 		}
 
 		/// Start recording at this moment; this is used in conjunction with the “-noautostart” command line.
-		public func start() throws {
-			try standardInput.fileHandleForWriting
-				.write(contentsOf: Data("<start/>\n".utf8))
+		public func start() async throws {
+			try await send("<start/>\n")
 		}
 
 		/// This will cancel recording and exit the moment that the file is completely on disk.
-		public func stop() throws {
-			try standardInput.fileHandleForWriting
-				.write(contentsOf: Data("<exit/>\n".utf8))
+		public func stop() async throws {
+			try await send("<exit/>\n")
 		}
 
 		/// Immediately stop recording, then restart another file without dropping frames.
-		public func chop(filename: String? = nil) throws {
-			try standardInput.fileHandleForWriting
-				.write(contentsOf: Data("<record_chop/>\n".utf8))
+		public func chop(filename: String? = nil) async throws {
+			try await send("<record_chop/>\n")
 		}
 
 		/// Immediately stop recording, and start recording another file in potentially a different location without dropping frames. This allows a recording location to be changed on the fly, allowing you to span recordings across multiple drives or locations.
-		public func chop(filename: String) throws {
-			try standardInput.fileHandleForWriting
-				.write(contentsOf: Data(#"<record_chop filename="\#(filename)"/>\n"#.utf8))
+		public func chop(filename: String) async throws {
+			try await send(#"<record_chop filename="\#(filename)"/>\n"#)
 		}
 
 		/// This allows you to control the current recorded audio levels in decibels. 1.2 would apply 1.2 dB of gain to the audio signal while recording to disk.
-		public func setRecordLevelGain(_ gain: Float) throws {
-			try standardInput.fileHandleForWriting
-				.write(contentsOf: Data(#"<record_level gain="\#(gain)"/>\n"#.utf8))
+		public func setRecordLevelGain(_ gain: Float) async throws {
+			try await send(#"<record_level gain="\#(gain)"/>\n"#)
 		}
 
 		/// Enable (or disable) automatic gain control for audio, which will use an expander/compressor to normalize the audio while it is being recorded.
-		public func setAutomaticGainControl(_ isOn: Bool) throws {
-			try standardInput.fileHandleForWriting
-				.write(contentsOf: Data(#"<record_agc enabled="\#(isOn)"/>\n"#.utf8))
+		public func setAutomaticGainControl(_ isOn: Bool) async throws {
+			try await send(#"<record_agc enabled="\#(isOn)"/>\n"#)
+		}
+
+		private func send(_ value: String) async throws {
+			guard let commandContinuation else {
+				throw RecorderError.notRunning
+			}
+
+			try await withCheckedThrowingContinuation { acknowledgement in
+				let command = Command(value: value, acknowledgement: acknowledgement)
+				switch commandContinuation.yield(command) {
+				case .enqueued:
+					break
+				case .dropped, .terminated:
+					acknowledgement.resume(throwing: RecorderError.notRunning)
+				@unknown default:
+					acknowledgement.resume(throwing: RecorderError.notRunning)
+				}
+			}
 		}
 
 		public struct MessageStream: AsyncSequence {
-			typealias UnderlyingStream = AsyncCompactMapSequence<AsyncLineSequence<FileHandle.AsyncBytes>, NDIMessage>
+			typealias UnderlyingStream = AsyncThrowingStream<NDIMessage, any Error>
 
 			fileprivate let underlyingStream: UnderlyingStream
 
@@ -168,6 +212,33 @@
 					try await underlyingIterator.next(isolation: actor)
 				}
 			}
+		}
+
+		private struct Command: Sendable {
+			let value: String
+			let acknowledgement: CheckedContinuation<Void, any Error>
+		}
+
+		private enum RecorderError: Error {
+			case notRunning
+		}
+	}
+
+	private actor LaunchSignal {
+		private var continuation: CheckedContinuation<Void, any Error>?
+
+		init(continuation: CheckedContinuation<Void, any Error>) {
+			self.continuation = continuation
+		}
+
+		func succeed() {
+			continuation?.resume()
+			continuation = nil
+		}
+
+		func fail(with error: any Error) {
+			continuation?.resume(throwing: error)
+			continuation = nil
 		}
 	}
 #endif

--- a/Sources/NDI/Recording/NDIRecorder.swift
+++ b/Sources/NDI/Recording/NDIRecorder.swift
@@ -10,8 +10,6 @@
 	///
 	/// You will need to have access to the NDI recording executable at runtime. When the NDI SDK is installed, this is located at `/Library/NDI\ SDK\ for\ Apple/bin/Application.Mac.NDI.Recording`.
 	public final class NDIRecorder {
-		private var commandContinuation: AsyncStream<Command>.Continuation?
-
 		public let inputName: String
 
 		public let executableURL: URL
@@ -26,15 +24,18 @@
 		}
 
 		/// Connect to the NDI source and prepare to record.
+		/// The recording and its message stream are valid only for the duration of `body`.
 		/// - Parameters:
 		///   - writeThumbnail: Whether a proxy file should be written.
-		///   - autostart: This command may be used to achieve frame-accurate recording as needed. When specified, the record application will run and connect to the remote source; however, it will not immediately start recording. It will then start immediately when you call ``start()``.
+		///   - autostart: This command may be used to achieve frame-accurate recording as needed. When specified, the record application will run and connect to the remote source; however, it will not immediately start recording. It will then start immediately when you call ``Recording/start()``.
 		///   - autochop: This specifies that if the video properties change (resolution, framerate, aspect ratio), the existing file is chopped, and a new one starts with a number appended. When false, it will simply exit when the video properties change, allowing you to start it again with a new file name should you want. By default, if the video format changes, it will open a new file in that format without dropping any frames.
-		@discardableResult public func launch(
+		///   - body: An asynchronous operation that controls the recording and consumes its messages.
+		public func launch<Result: Sendable>(
 			writeThumbnail: Bool = true,
 			autostart: Bool = true,
-			autochop: Bool = true
-		) async throws -> MessageStream {
+			autochop: Bool = true,
+			body: (Recording) async throws -> Result
+		) async throws -> Result {
 			let inputName = self.inputName
 			let executablePath = executableURL.path(percentEncoded: false)
 
@@ -68,120 +69,85 @@
 			if !autostart {
 				arguments.append("-noautostart")
 			}
-			let processArguments = arguments
-
 			logger.info("starting recording of '\(inputName)' at '\(outputPath)'")
 
-			let (messageStream, messageContinuation) = AsyncThrowingStream.makeStream(of: NDIMessage.self)
-			let (commands, commandContinuation) = AsyncStream.makeStream(of: Command.self)
-			self.commandContinuation = commandContinuation
-
-			try await withCheckedThrowingContinuation { continuation in
-				let launchSignal = LaunchSignal(continuation: continuation)
-				Task {
-					do {
-						_ = try await run(
-							.path(.init(executablePath)),
-							arguments: .init(processArguments),
-							input: .inputWriter,
-							output: .sequence,
-							error: .sequence
-						) { execution in
-							await launchSignal.succeed()
-
-							try await withThrowingTaskGroup(of: Void.self) { group in
-								group.addTask {
-									defer { commandContinuation.finish() }
-									for try await line in execution.standardOutput.strings() {
-										do {
-											messageContinuation.yield(try NDIMessageParser.parse(line: line))
-										} catch {
-											logger.error("failed to decode message '\(line)': \(error)")
-										}
-									}
-								}
-								group.addTask {
-									for try await line in execution.standardError.strings() {
-										logger.info("\(line)")
-									}
-								}
-								group.addTask {
-									for await command in commands {
-										do {
-											_ = try await execution.standardInputWriter.write(command.value)
-											command.acknowledgement.resume()
-										} catch {
-											command.acknowledgement.resume(throwing: error)
-											throw error
-										}
-									}
-									try await execution.standardInputWriter.finish()
-								}
-								try await group.waitForAll()
-							}
-						}
-						messageContinuation.finish()
-					} catch {
-						await launchSignal.fail(with: error)
-						commandContinuation.finish()
-						messageContinuation.finish(throwing: error)
+			let executionResult = try await run(
+				.path(.init(executablePath)),
+				arguments: .init(arguments),
+				input: .inputWriter,
+				output: .sequence,
+				error: .sequence
+			) { execution in
+				async let logStandardError: Void = {
+					for try await line in execution.standardError.strings() {
+						logger.info("\(line)")
 					}
-				}
+				}()
+
+				let messages = execution.standardOutput.strings()
+					.compactMap { line in
+						do {
+							return try NDIMessageParser.parse(line: line)
+						} catch {
+							logger.error("failed to decode message '\(line)': \(error)")
+							return nil
+						}
+					}
+				let recording = Recording(
+					messages: MessageStream(underlyingStream: messages),
+					standardInputWriter: execution.standardInputWriter
+				)
+				let result = try await body(recording)
+				try await execution.standardInputWriter.finish()
+				try await logStandardError
+				return result
 			}
 
-			return MessageStream(underlyingStream: messageStream)
+			return executionResult.closureResult
 		}
 
-		/// Start recording at this moment; this is used in conjunction with the “-noautostart” command line.
-		public func start() async throws {
-			try await send("<start/>\n")
-		}
+		/// A scoped interface to a running NDI recording process.
+		public struct Recording {
+			public let messages: MessageStream
 
-		/// This will cancel recording and exit the moment that the file is completely on disk.
-		public func stop() async throws {
-			try await send("<exit/>\n")
-		}
+			fileprivate let standardInputWriter: StandardInputWriter
 
-		/// Immediately stop recording, then restart another file without dropping frames.
-		public func chop(filename: String? = nil) async throws {
-			try await send("<record_chop/>\n")
-		}
-
-		/// Immediately stop recording, and start recording another file in potentially a different location without dropping frames. This allows a recording location to be changed on the fly, allowing you to span recordings across multiple drives or locations.
-		public func chop(filename: String) async throws {
-			try await send(#"<record_chop filename="\#(filename)"/>\n"#)
-		}
-
-		/// This allows you to control the current recorded audio levels in decibels. 1.2 would apply 1.2 dB of gain to the audio signal while recording to disk.
-		public func setRecordLevelGain(_ gain: Float) async throws {
-			try await send(#"<record_level gain="\#(gain)"/>\n"#)
-		}
-
-		/// Enable (or disable) automatic gain control for audio, which will use an expander/compressor to normalize the audio while it is being recorded.
-		public func setAutomaticGainControl(_ isOn: Bool) async throws {
-			try await send(#"<record_agc enabled="\#(isOn)"/>\n"#)
-		}
-
-		private func send(_ value: String) async throws {
-			guard let commandContinuation else {
-				throw RecorderError.notRunning
+			/// Start recording at this moment; this is used in conjunction with the “-noautostart” command line.
+			public func start() async throws {
+				_ = try await standardInputWriter.write("<start/>\n")
 			}
 
-			try await withCheckedThrowingContinuation { acknowledgement in
-				let command = Command(value: value, acknowledgement: acknowledgement)
-				switch commandContinuation.yield(command) {
-				case .enqueued:
-					break
-				case .dropped, .terminated:
-					acknowledgement.resume(throwing: RecorderError.notRunning)
-				@unknown default:
-					acknowledgement.resume(throwing: RecorderError.notRunning)
-				}
+			/// This will cancel recording and exit the moment that the file is completely on disk.
+			public func stop() async throws {
+				_ = try await standardInputWriter.write("<exit/>\n")
+			}
+
+			/// Immediately stop recording, then restart another file without dropping frames.
+			public func chop() async throws {
+				_ = try await standardInputWriter.write("<record_chop/>\n")
+			}
+
+			/// Immediately stop recording, and start recording another file in potentially a different location without dropping frames. This allows a recording location to be changed on the fly, allowing you to span recordings across multiple drives or locations.
+			public func chop(filename: String) async throws {
+				_ = try await standardInputWriter.write(#"<record_chop filename="\#(filename)"/>\n"#)
+			}
+
+			/// This allows you to control the current recorded audio levels in decibels. 1.2 would apply 1.2 dB of gain to the audio signal while recording to disk.
+			public func setRecordLevelGain(_ gain: Float) async throws {
+				_ = try await standardInputWriter.write(#"<record_level gain="\#(gain)"/>\n"#)
+			}
+
+			/// Enable (or disable) automatic gain control for audio, which will use an expander/compressor to normalize the audio while it is being recorded.
+			public func setAutomaticGainControl(_ isOn: Bool) async throws {
+				_ = try await standardInputWriter.write(#"<record_agc enabled="\#(isOn)"/>\n"#)
 			}
 		}
 
 		public struct MessageStream: AsyncSequence {
-			typealias UnderlyingStream = AsyncThrowingStream<NDIMessage, any Error>
+			typealias UnderlyingStream = AsyncCompactMapSequence<
+				SubprocessOutputSequence.StringSequence<UTF8>,
+				NDIMessage
+			>
 
 			fileprivate let underlyingStream: UnderlyingStream
 
@@ -200,10 +166,6 @@
 
 				fileprivate var underlyingIterator: UnderlyingStream.AsyncIterator
 
-				fileprivate init(underlyingIterator: UnderlyingStream.AsyncIterator) {
-					self.underlyingIterator = underlyingIterator
-				}
-
 				public mutating func next() async throws -> NDIMessage? {
 					try await underlyingIterator.next()
 				}
@@ -212,33 +174,6 @@
 					try await underlyingIterator.next(isolation: actor)
 				}
 			}
-		}
-
-		private struct Command: Sendable {
-			let value: String
-			let acknowledgement: CheckedContinuation<Void, any Error>
-		}
-
-		private enum RecorderError: Error {
-			case notRunning
-		}
-	}
-
-	private actor LaunchSignal {
-		private var continuation: CheckedContinuation<Void, any Error>?
-
-		init(continuation: CheckedContinuation<Void, any Error>) {
-			self.continuation = continuation
-		}
-
-		func succeed() {
-			continuation?.resume()
-			continuation = nil
-		}
-
-		func fail(with error: any Error) {
-			continuation?.resume(throwing: error)
-			continuation = nil
 		}
 	}
 #endif

--- a/Tests/NDITests/NDIReceiverTests.swift
+++ b/Tests/NDITests/NDIReceiverTests.swift
@@ -192,6 +192,8 @@ private extension NDIReceivedFrame {
 			"audio"
 		case .metadata:
 			"metadata"
+		case .marker:
+			"marker"
 		case .statusChange:
 			"statusChange"
 		case .unknown:

--- a/Tests/NDITests/NDIRecorderTests.swift
+++ b/Tests/NDITests/NDIRecorderTests.swift
@@ -33,44 +33,46 @@
 			)
 
 			let recorder = NDIRecorder(inputName: "Test Input", executableURL: executableURL)
-			var messages = try await recorder.launch(autostart: false).makeAsyncIterator()
+			let result = try await recorder.launch(autostart: false) { recording in
+				var messages = recording.messages.makeAsyncIterator()
 
-			#expect(
-				try await messages.next() == .recordStarted(
-					.init(
-						filename: "test.mov",
-						previewFilename: "test.mov.preview",
-						frameRateNumerator: 30_000,
-						frameRateDenominator: 1_000,
-						xResolution: nil,
-						yResolution: nil
+				#expect(
+					try await messages.next() == .recordStarted(
+						.init(
+							filename: "test.mov",
+							previewFilename: "test.mov.preview",
+							frameRateNumerator: 30_000,
+							frameRateDenominator: 1_000,
+							xResolution: nil,
+							yResolution: nil
+						)
 					)
 				)
-			)
 
-			try await recorder.start()
-			#expect(
-				try await messages.next() == .recording(
-					.init(
-						numberOfFramesWritten: 1,
-						timecode: 100,
-						realTimecodeInFlight: 101,
-						vuDB: -12.5,
-						startTimecode: nil
+				try await recording.start()
+				#expect(
+					try await messages.next() == .recording(
+						.init(
+							numberOfFramesWritten: 1,
+							timecode: 100,
+							realTimecodeInFlight: 101,
+							vuDB: -12.5,
+							startTimecode: nil
+						)
 					)
 				)
-			)
 
-			try await recorder.stop()
-			#expect(
-				try await messages.next() == .recordStopped(
-					.init(numberOfFramesWritten: 1, lastTimecode: 100)
+				try await recording.stop()
+				#expect(
+					try await messages.next() == .recordStopped(
+						.init(numberOfFramesWritten: 1, lastTimecode: 100)
+					)
 				)
-			)
-			#expect(try await messages.next() == nil)
-			await #expect(throws: (any Error).self) {
-				try await recorder.start()
+				#expect(try await messages.next() == nil)
+				return "finished"
 			}
+
+			#expect(result == "finished")
 		}
 
 		@Test
@@ -81,7 +83,7 @@
 			)
 
 			await #expect(throws: (any Error).self) {
-				_ = try await recorder.launch()
+				try await recorder.launch { _ in }
 			}
 		}
 	}

--- a/Tests/NDITests/NDIRecorderTests.swift
+++ b/Tests/NDITests/NDIRecorderTests.swift
@@ -1,0 +1,88 @@
+#if os(macOS)
+	import Foundation
+	import Testing
+
+	@testable import NDI
+
+	struct NDIRecorderTests {
+		@Test
+		func streamsMessagesAndSendsCommands() async throws {
+			let executableURL = FileManager.default.temporaryDirectory
+				.appending(path: UUID().uuidString)
+			defer { try? FileManager.default.removeItem(at: executableURL) }
+
+			let executable = #"""
+			#!/bin/sh
+			printf '<record_started filename="test.mov" filename_pvw="test.mov.preview" frame_rate_n="30000" frame_rate_d="1000"/>\n'
+			while IFS= read -r command; do
+				case "$command" in
+					'<start/>')
+						printf '<recording no_frames="1" timecode="100" real_timecode_inflight="101" vu_dB="-12.5"/>\n'
+						;;
+					'<exit/>')
+						printf '<record_stopped no_frames="1" last_timecode="100"/>\n'
+						exit 0
+						;;
+				esac
+			done
+			"""#
+			try Data(executable.utf8).write(to: executableURL)
+			try FileManager.default.setAttributes(
+				[.posixPermissions: 0o700],
+				ofItemAtPath: executableURL.path()
+			)
+
+			let recorder = NDIRecorder(inputName: "Test Input", executableURL: executableURL)
+			var messages = try await recorder.launch(autostart: false).makeAsyncIterator()
+
+			#expect(
+				try await messages.next() == .recordStarted(
+					.init(
+						filename: "test.mov",
+						previewFilename: "test.mov.preview",
+						frameRateNumerator: 30_000,
+						frameRateDenominator: 1_000,
+						xResolution: nil,
+						yResolution: nil
+					)
+				)
+			)
+
+			try await recorder.start()
+			#expect(
+				try await messages.next() == .recording(
+					.init(
+						numberOfFramesWritten: 1,
+						timecode: 100,
+						realTimecodeInFlight: 101,
+						vuDB: -12.5,
+						startTimecode: nil
+					)
+				)
+			)
+
+			try await recorder.stop()
+			#expect(
+				try await messages.next() == .recordStopped(
+					.init(numberOfFramesWritten: 1, lastTimecode: 100)
+				)
+			)
+			#expect(try await messages.next() == nil)
+			await #expect(throws: (any Error).self) {
+				try await recorder.start()
+			}
+		}
+
+		@Test
+		func reportsLaunchFailure() async {
+			let recorder = NDIRecorder(
+				inputName: "Test Input",
+				executableURL: URL(filePath: "/does/not/exist")
+			)
+
+			await #expect(throws: (any Error).self) {
+				_ = try await recorder.launch()
+			}
+		}
+	}
+#endif


### PR DESCRIPTION
## Summary

- add swift-subprocess 1.0.0 and raise the package tools version to Swift 6.2
- model NDI recording as a scoped async operation that directly follows the swift-subprocess run closure lifetime
- expose a Recording value whose control methods write directly through StandardInputWriter
- wrap SubprocessOutputSequence directly as the parsed MessageStream, allowing subprocess read failures to propagate naturally
- add integration coverage for message streaming, commands, launch failures, and scoped return values
- handle the existing marker case in the receiver test helper so the full test target compiles

## Testing

- swift test --disable-sandbox (39 tests passed)